### PR TITLE
Better str and repr for objects

### DIFF
--- a/shinken/objects/command.py
+++ b/shinken/objects/command.py
@@ -96,9 +96,6 @@ class Command(Item):
     def get_name(self):
         return self.command_name
 
-    def __str__(self):
-        return str(self.__dict__)
-
     def fill_data_brok_from(self, data, brok_type):
         cls = self.__class__
         # Now config properties

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -212,6 +212,8 @@ Like temporary attributes such as "imported_from", etc.. """
         cls_name = self.__class__.__name__
         return '<%s "name"=%r />' % (cls_name, self.get_name())
 
+    __repr__ = __str__
+
     def is_tpl(self):
         """ Return if the elements is a template """
         return not getattr(self, "register", True)
@@ -1084,6 +1086,8 @@ class Items(object):
     def __str__(self):
         return '<%s nbr_elements=%s nbr_templates=%s />' % (
             self.__class__.__name__, len(self), len(self.templates))
+
+    __repr__ = __str__
 
     # Inheritance for just a property
     def apply_partial_inheritance(self, prop):

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -205,8 +205,12 @@ Like temporary attributes such as "imported_from", etc.. """
             except AttributeError:
                 pass
 
+    def get_name(self):
+        return getattr(self, 'name', "unknown")
+
     def __str__(self):
-        return str(self.__dict__) + '\n'
+        cls_name = self.__class__.__name__
+        return '<%s "name"=%r />' % (cls_name, self.get_name())
 
     def is_tpl(self):
         """ Return if the elements is a template """

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -1085,7 +1085,7 @@ class Items(object):
 
     def __str__(self):
         return '<%s nbr_elements=%s nbr_templates=%s />' % (
-            self.__class__.__name__, len(self), len(self.templates))
+            self.__class__.__name__, len(self), len(self.name_to_template))
 
     __repr__ = __str__
 

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -1082,11 +1082,8 @@ class Items(object):
             i.fill_default()
 
     def __str__(self):
-        s = ''
-        cls = self.__class__
-        for id in self.items:
-            s = s + str(cls) + ':' + str(id) + str(self.items[id]) + '\n'
-        return s
+        return '<%s nbr_elements=%s nbr_templates=%s />' % (
+            self.__class__.__name__, len(self), len(self.templates))
 
     # Inheritance for just a property
     def apply_partial_inheritance(self, prop):

--- a/shinken/objects/itemgroup.py
+++ b/shinken/objects/itemgroup.py
@@ -111,9 +111,6 @@ class Itemgroup(Item):
             self.unknown_members = []
         add_fun(self.unknown_members, member)
 
-    def __str__(self):
-        return str(self.__dict__) + '\n'
-
     def __iter__(self):
         return self.members.__iter__()
 

--- a/shinken/objects/module.py
+++ b/shinken/objects/module.py
@@ -50,6 +50,8 @@ class Module(Item):
     def __repr__(self):
         return '<module type=%s name=%s />' % (self.module_type, self.module_name)
 
+    __str__ = __repr__
+
 
 class Modules(Items):
     name_property = "module_name"


### PR DESCRIPTION
So to have better view/repr of objects when in debug sessions.

Main thing done is : 
don't anymore return str(self.\_\_dict\_\_) (or str(self.items) for Items classes) for the \_\_str\_\_ or \_\_repr\_\_ methods of objects. 
That was more overkill than useful (and has even caused some problem when using that "feature" in debug sessions).