### PR TITLE
Enh/Fix: make modules still compatible with us  [WIP]

### DIFF
--- a/alignak/__init__.py
+++ b/alignak/__init__.py
@@ -42,3 +42,7 @@
 #
 #  You should have received a copy of the GNU Affero General Public License
 #  along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+from . import shinken_dependency_fix

--- a/alignak/shinken_dependency_fix.py
+++ b/alignak/shinken_dependency_fix.py
@@ -1,0 +1,113 @@
+
+import importlib
+import sys
+
+# This is a simple hack that should make external modules / tools,
+# able to continue to work with us ..
+
+import alignak
+sys.modules['shinken'] = alignak
+
+for name in (
+    'acknowledge',
+    'action',
+    'basemodule',
+    'brok',
+    'comment',
+    'commandcall',
+    'downtime',
+    'eventhandler',
+    'external_command',
+    'http_client',
+    'http_daemon',
+    'load',
+    'log',
+    'macroresolver',
+    'memoized',
+    'message',
+    'modulesctx',
+    'modulesmanager',
+    'notification',
+    'property',
+
+    'old_daemon_link',
+    'arbiterlink',
+    'brokerlink',
+    'pollerlink',
+    'schedulerlink',
+    'reactionnerlink',
+    'receiverlink',
+
+    'scheduler',
+    'satellite',
+
+    'stats',
+    'trigger_functions',
+    'util',
+    'worker',
+
+
+    'daemons',
+    'daemons.arbiterdaemon',
+    'daemons.brokerdaemon',
+    'daemons.pollerdaemon',
+    'daemons.reactionnerdaemon',
+    'daemons.receiverdaemon',
+    'daemons.schedulerdaemon',
+
+
+    'objects',
+    'objects.arbiterlink',
+    'objects.brokerlink',
+    'objects.businessimpactmodulation',
+    'objects.checkmodulation',
+    'objects.command',
+    'objects.config',
+    'objects.contact',
+    'objects.contactgroup',
+    'objects.discoveryrule',
+    'objects.discoveryrun',
+    'objects.escalation',
+    'objects.host',
+    'objects.hostdependency',
+    'objects.hostescalation',
+    'objects.hostextinfo',
+    'objects.hostgroup',
+    'objects.item',
+    'objects.itemgroup',
+    'objects.macromodulation',
+    'objects.matchingitem',
+    'objects.module',
+    'objects.notificationway',
+    'objects.pack',
+    'objects.pollerlink',
+    'objects.reactionnerlink',
+    'objects.realm',
+    'objects.receiverlink',
+    'objects.resultmodulation',
+    'objects.satellitelink',
+    'objects.schedulerlink',
+    'objects.schedulingitem',
+    'objects.service',
+    'objects.servicedependency',
+    'objects.serviceescalation',
+    'objects.serviceextinfo',
+    'objects.servicegroup',
+    'objects.timeperiod',
+    'objects.trigger',
+
+    'misc',
+    'misc.common',
+    'misc.datamanager',
+    'misc.filter',
+    'misc.importlib',
+    'misc._importlib',
+    'misc.logevent',
+    'misc.md5crypt',
+    'misc.perfdata',
+    'misc.regenerator',
+    'misc.sorter',
+    'misc.termcolor',
+):
+    mod = importlib.import_module('alignak.%s' % name)
+    sys.modules['shinken.%s' % name] = mod


### PR DESCRIPTION
Used the most simple trick : load all alignak modules and use them as "alias" in sys.modules.

An import hook could also have been used I'm pretty sure, which could have been better (I gave it a try but had slight problems so I've fallback on the above possibility).