### PR TITLE
[WIP] Travis enh: fix coverage mess with test_bad_start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 # so we must combine them in the end
 script:
   - cd test
-  - nosetests -xv --process-restartworker --processes=1 --process-timeout=999999999  --with-cov --cov=alignak
+  - nosetests -xv --process-restartworker --processes=1 --process-timeout=999999999  --with-coverage --cover-package=alignak
   - coverage combine
   - cd .. && pep8 --max-line-length=100 --ignore=E303,E302,E301,E241 --exclude='*.pyc' alignak/*
 # specific call to launch coverage data into coveralls.io

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -733,7 +733,7 @@ class Daemon(object):
         self.http_daemon = HTTPDaemon(self.host, self.port, http_backend,
                                       use_ssl, ca_cert, ssl_key,
                                       ssl_cert, ssl_conf.hard_ssl_name_check,
-                                      self.daemon_thread_pool_size)
+                                      self.daemon_thread_pool_size, self)
         # TODO: fix this "hack" :
         alignak.http_daemon.daemon_inst = self.http_daemon
 

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -342,6 +342,10 @@ class Daemon(object):
                 pass
             self.http_daemon.shutdown()
 
+        # give some time to http_daemon main thread (and the "worker"
+        # threads too, if any) to cleanly shutdown:
+        time.sleep(0.5)
+
 
     def request_stop(self):
         self.unlink()

--- a/alignak/http_daemon.py
+++ b/alignak/http_daemon.py
@@ -205,8 +205,10 @@ class WSGIREFAdapter (bottle.ServerAdapter):
 
 class WSGIREFBackend(object):
     def __init__(self, host, port, use_ssl, ca_cert, ssl_key,
-                 ssl_cert, hard_ssl_name_check, daemon_thread_pool_size):
+                 ssl_cert, hard_ssl_name_check, daemon_thread_pool_size,
+                 satellite_daemon):
         self.daemon_thread_pool_size = daemon_thread_pool_size
+        self.satellite_daemon = satellite_daemon
         try:
             self.srv = bottle.run(host=host, port=port,
                                   server=WSGIREFAdapter, quiet=True, use_ssl=use_ssl,
@@ -255,11 +257,11 @@ class WSGIREFBackend(object):
         # Keep a list of our running threads
         threads = []
         logger.info('Using a %d http pool size', nb_threads)
-        while True:
+        while not self.satellite_daemon.interrupted:
             # We must not run too much threads, so we will loop until
             # we got at least one free slot available
             free_slots = 0
-            while free_slots <= 0:
+            while free_slots <= 0 and not self.satellite_daemon.interrupted:
                 to_del = [t for t in threads if not t.is_alive()]
                 for t in to_del:
                     t.join()
@@ -284,6 +286,8 @@ class WSGIREFBackend(object):
                     t.start()
                     threads.append(t)
 
+        for t in threads:
+            t.join()
 
     def handle_one_request_thread(self, sock):
         self.srv.handle_request()
@@ -292,7 +296,8 @@ class WSGIREFBackend(object):
 
 class HTTPDaemon(object):
         def __init__(self, host, port, http_backend, use_ssl, ca_cert,
-                     ssl_key, ssl_cert, hard_ssl_name_check, daemon_thread_pool_size):
+                     ssl_key, ssl_cert, hard_ssl_name_check, daemon_thread_pool_size,
+                     satellite_daemon):
             self.port = port
             self.host = host
             self.srv = None
@@ -316,14 +321,18 @@ class HTTPDaemon(object):
             __import__('BaseHTTPServer').BaseHTTPRequestHandler.address_string = \
                 lambda x: x.client_address[0]
 
+            self.lock = threading.RLock()
+            self.satellite_daemon = satellite_daemon
+
             if http_backend == 'cherrypy' or http_backend == 'auto' and cheery_wsgiserver:
                 self.srv = CherryPyBackend(host, port, use_ssl, ca_cert, ssl_key,
                                            ssl_cert, hard_ssl_name_check, daemon_thread_pool_size)
             else:
                 self.srv = WSGIREFBackend(host, port, use_ssl, ca_cert, ssl_key,
-                                          ssl_cert, hard_ssl_name_check, daemon_thread_pool_size)
+                                          ssl_cert, hard_ssl_name_check,
+                                          daemon_thread_pool_size, satellite_daemon)
 
-            self.lock = threading.RLock()
+
 
 
         # Get the server socket but not if disabled or closed

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,6 +5,7 @@ mock
 coveralls==0.5
 nose-cov==1.6
 coverage==3.7.1
-nose==1.3.4
+nose==1.3.6
 pylint==1.4.1
 pep8==1.5.7
+cov-core==1.15.0

--- a/test/setup_test.sh
+++ b/test/setup_test.sh
@@ -27,3 +27,6 @@ cd $BASE_PATH
 # install prog AND tests requirements :
 pip install -r test/requirements.txt
 python setup.py develop
+
+# for eventual debug help to know what libs versions we have:
+pip freeze


### PR DESCRIPTION
so to _shutdown_ an annoying prob during coverage :

test_port_not_free (test_bad_start.Test_Scheduler_Bad_Start) ... ok
Coverage.py warning: No data was collected.
Traceback (most recent call last):
  File "/opt/python/2.6.9/lib/python2.6/multiprocessing/util.py", line 235, in _run_finalizers
    finalizer()
  File "/opt/python/2.6.9/lib/python2.6/multiprocessing/util.py", line 174, in __call__
    res = self._callback(*self._args, **self._kwargs)
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/cov_core.py", line 20, in multiprocessing_finish
    cov.save()
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/coverage/control.py", line 493, in save
    self.data.write(suffix=data_suffix)
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/coverage/data.py", line 91, in write
    self.write_file(filename)
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/coverage/data.py", line 131, in write_file
    fdata = open(filename, 'wb')
IOError: [Errno 2] No such file or directory: '/tmp/tmpOumlg1/.coverage.testing-worker-linux-027f0490-2-7771-linux-4-50667445.3028.493619'