### PR TITLE
Clean daemons & http shutdown

### DIFF
--- a/alignak/basemodule.py
+++ b/alignak/basemodule.py
@@ -315,7 +315,7 @@ class BaseModule(object):
 
         # TODO: fix this hack:
         if alignak.http_daemon.daemon_inst:
-            alignak.http_daemon.daemon_inst.shutdown()
+            alignak.http_daemon.daemon_inst.close_sockets()
 
         self.set_signal_handler()
         logger.info("[%s[%d]]: Now running..", self.name, os.getpid())

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -324,18 +324,6 @@ class Daemon(object):
 
     # At least, lose the local log file if needed
     def do_stop(self):
-        # Maybe the modules manager is not even created!
-        if getattr(self, 'modules_manager', None):
-            # We save what we can but NOT for the scheduler
-            # because the current sched object is a dummy one
-            # and the old one has already done it!
-            if not hasattr(self, 'sched'):
-                self.hook_point('save_retention')
-            # And we quit
-            print('Stopping all modules')
-            self.modules_manager.stop_all()
-            print('Stopping inter-process message')
-
         if self.http_daemon:
             # Release the lock so the daemon can shutdown without problem
             try:
@@ -349,10 +337,21 @@ class Daemon(object):
             self.http_thread.join()
             self.http_thread = None
 
-
         if self.manager:
             self.manager.shutdown()
             self.manager = None
+
+        # Maybe the modules manager is not even created!
+        if getattr(self, 'modules_manager', None):
+            # We save what we can but NOT for the scheduler
+            # because the current sched object is a dummy one
+            # and the old one has already done it!
+            if not hasattr(self, 'sched'):
+                self.hook_point('save_retention')
+            # And we quit
+            print('Stopping all modules')
+            self.modules_manager.stop_all()
+            print('Stopping inter-process message')
 
 
     def request_stop(self):

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -119,6 +119,8 @@ except ImportError, exp:  # Like in nt system or Android
         return []
 
 
+IS_PY26 = sys.version_info[:2] < (2, 7)
+
 # #########################   DAEMON PART    ###############################
 # The standard I/O file descriptors are redirected to /dev/null by default.
 REDIRECT_TO = getattr(os, "devnull", "/dev/null")
@@ -324,20 +326,29 @@ class Daemon(object):
 
     # At least, lose the local log file if needed
     def do_stop(self):
+        """Execute the stop of this daemon:
+         - Stop the http thread and join it
+         - Close the http socket
+         - Shutdown the manager
+         - Stop and join all started "modules"
+        """
+        logger.info("%s : Doing stop ..", self)
+
         if self.http_daemon:
-            # Release the lock so the daemon can shutdown without problem
-            try:
-                self.http_daemon.lock.release()
-            except Exception:
-                pass
-            self.http_daemon.shutdown()
-            self.http_daemon = None
+            logger.info("Shutting down http_daemon ..")
+            self.http_daemon.request_stop()
 
         if self.http_thread:
+            logger.info("Joining http_thread ..")
             self.http_thread.join()
             self.http_thread = None
 
+        if self.http_daemon:
+            self.http_daemon.close_sockets()
+            self.http_daemon = None
+
         if self.manager:
+            logger.info("Shutting down manager ..")
             self.manager.shutdown()
             self.manager = None
 
@@ -349,9 +360,10 @@ class Daemon(object):
             if not hasattr(self, 'sched'):
                 self.hook_point('save_retention')
             # And we quit
-            print('Stopping all modules')
+            logger.info('Stopping all modules')
             self.modules_manager.stop_all()
-            print('Stopping inter-process message')
+
+        logger.info("%s : All stop done.", self)
 
 
     def request_stop(self):
@@ -640,21 +652,9 @@ class Daemon(object):
         # a socket of your http server alive
         def _create_manager(self):
             manager = SyncManager(('127.0.0.1', 0))
-            def close_http_daemon(daemon):
-                try:
-                    # Be sure to release the lock so there won't be lock in shutdown phase
-                    daemon.lock.release()
-                except Exception, exp:
-                    pass
-                daemon.shutdown()
-            # Some multiprocessing lib got problems with start() that cannot take args
-            # so we must look at it before
-            startargs = inspect.getargspec(manager.start)
-            # startargs[0] will be ['self'] if old multiprocessing lib
-            # and ['self', 'initializer', 'initargs'] in newer ones
-            # note: windows do not like pickle http_daemon...
-            if os.name != 'nt' and len(startargs[0]) > 1:
-                manager.start(close_http_daemon, initargs=(self.http_daemon,))
+            if os.name != 'nt' and not IS_PY26:
+                # manager in python2.6 don't have initializer..
+                manager.start(initializer=self.http_daemon.close_sockets)
             else:
                 manager.start()
             return manager
@@ -690,9 +690,9 @@ class Daemon(object):
         else:
             self.write_pid()
 
-        # Now we can start our Manager
-        # interprocess things. It's important!
+        logger.info("Creating manager ..")
         self.manager = self._create_manager()
+        logger.info("done.")
 
         # We can start our stats thread but after the double fork() call and if we are not in
         # a test launch (time.time() is hooked and will do BIG problems there)
@@ -702,9 +702,8 @@ class Daemon(object):
         # Now start the http_daemon thread
         if use_pyro:
             # Directly acquire it, so the http_thread will wait for us
-            self.http_daemon.lock.acquire()
+            logger.info("Now starting http_daemon thread..")
             self.http_thread = threading.Thread(None, self.http_daemon_thread, 'http_thread')
-            # Don't lock the main thread just because of the http thread
             self.http_thread.daemon = True
             self.http_thread.start()
 
@@ -950,7 +949,7 @@ class Daemon(object):
 
     # Main fonction of the http daemon thread will loop forever unless we stop the root daemon
     def http_daemon_thread(self):
-        logger.info("Starting HTTP daemon")
+        logger.info("HTTP main thread: I'm running")
 
         # The main thing is to have a pool of X concurrent requests for the http_daemon,
         # so "no_lock" calls can always be directly answer without having a "locked" version to
@@ -982,14 +981,10 @@ class Daemon(object):
         socks = []
         if suppl_socks:
             socks.extend(suppl_socks)
-        # Release the lock so the http_thread can manage request during we are waiting
-        if self.http_daemon:
-            self.http_daemon.lock.release()
+
         # Ok give me the socks taht moved during the timeout max
         ins = self.get_socks_activity(socks, timeout)
         # Ok now get back the global lock!
-        if self.http_daemon:
-            self.http_daemon.lock.acquire()
         tcdiff = self.check_for_system_time_change()
         before += tcdiff
         # Increase our sleep time for the time go in select

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -958,12 +958,11 @@ class Daemon(object):
         try:
             self.http_daemon.run()
         except Exception, exp:
-            logger.error('The HTTP daemon failed with the error %s, exiting', str(exp))
+            logger.exception('The HTTP daemon failed with the error %s, exiting', str(exp))
             output = cStringIO.StringIO()
             traceback.print_exc(file=output)
             logger.error("Back trace of this error: %s", output.getvalue())
             output.close()
-            self.do_stop()
             # Hard mode exit from a thread
             os._exit(2)
 

--- a/alignak/daemons/schedulerdaemon.py
+++ b/alignak/daemons/schedulerdaemon.py
@@ -57,6 +57,9 @@ import traceback
 import cPickle
 import zlib
 import base64
+from multiprocessing import process
+
+
 
 from alignak.scheduler import Scheduler
 from alignak.macroresolver import MacroResolver
@@ -353,7 +356,7 @@ class Alignak(BaseSatellite):
                     c.t_to_go = new_t
 
     def manage_signal(self, sig, frame):
-        logger.warning("Received a SIGNAL %s", sig)
+        logger.warning("%s > Received a SIGNAL %s", process.current_process(), sig)
         # If we got USR1, just dump memory
         if sig == signal.SIGUSR1:
             self.sched.need_dump_memory = True

--- a/alignak/http_daemon.py
+++ b/alignak/http_daemon.py
@@ -310,6 +310,8 @@ class HTTPDaemon(object):
             self.registered_fun_names = []
             self.registered_fun_defaults = {}
 
+            self.lock = threading.RLock()
+
             protocol = 'http'
             if use_ssl:
                 protocol = 'https'
@@ -327,7 +329,6 @@ class HTTPDaemon(object):
                 self.srv = WSGIREFBackend(host, port, use_ssl, ca_cert, ssl_key,
                                           ssl_cert, hard_ssl_name_check, daemon_thread_pool_size)
 
-            self.lock = threading.RLock()
 
 
         # Get the server socket but not if disabled or closed

--- a/alignak/http_daemon.py
+++ b/alignak/http_daemon.py
@@ -213,6 +213,15 @@ class WSGIREFBackend(object):
                                   server=WSGIREFAdapter, quiet=True, use_ssl=use_ssl,
                                   ca_cert=ca_cert, ssl_key=ssl_key, ssl_cert=ssl_cert,
                                   daemon_thread_pool_size=daemon_thread_pool_size)
+            # small workaround:
+            # if a bad client connect to us and doesn't send anything,
+            # then the client thread that handle that connection will stay
+            # infinitely blocked.. in :
+            #   self.handle_one_request_thread() ->
+            #   SocketServer.py:BaseServer.handle_request() ->
+            #       fd_sets = select.select([self], [], [], timeout)
+            # with timeout == None ..
+            self.srv.timeout = 10
         except socket.error, exp:
             msg = "Error: Sorry, the port %d is not free: %s" % (port, str(exp))
             raise PortNotFree(msg)

--- a/alignak/worker.py
+++ b/alignak/worker.py
@@ -276,7 +276,7 @@ class Worker:
 
         print "I STOP THE http_daemon", self.http_daemon
         if self.http_daemon:
-            self.http_daemon.shutdown()
+            self.http_daemon.close_sockets()
 
         timeout = 1.0
         self.checks = []

--- a/test/etc/core/daemons/brokerd.ini
+++ b/test/etc/core/daemons/brokerd.ini
@@ -34,7 +34,7 @@ http_backend=auto
 use_local_log=1
 local_log=%(logdir)s/brokerd.log
 # Accepted log level values: DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+log_level=INFO
 
 
 #-- External modules watchdog --

--- a/test/etc/core/daemons/pollerd.ini
+++ b/test/etc/core/daemons/pollerd.ini
@@ -36,5 +36,5 @@ use_local_log=1
 local_log=%(logdir)s/pollerd.log
 
 # accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+log_level=INFO
 

--- a/test/etc/core/daemons/reactionnerd.ini
+++ b/test/etc/core/daemons/reactionnerd.ini
@@ -29,4 +29,4 @@ use_local_log=1
 local_log=%(logdir)s/reactionnerd.log
 
 # accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+log_level=INFO

--- a/test/etc/core/daemons/schedulerd.ini
+++ b/test/etc/core/daemons/schedulerd.ini
@@ -35,4 +35,4 @@ use_local_log=1
 local_log=%(logdir)s/schedulerd.log
 
 # accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+log_level=INFO

--- a/test/test_bad_start.py
+++ b/test/test_bad_start.py
@@ -54,8 +54,9 @@ from __future__ import print_function
 import os
 import tempfile
 import shutil
+import time
 
-from alignak_test import *
+from alignak_test import unittest, get_free_port, time_hacker
 
 import alignak.log as alignak_log
 
@@ -191,23 +192,23 @@ class template_Daemon_Bad_Start():
 
 #############################################################################
 
-class Test_Broker_Bad_Start(template_Daemon_Bad_Start, AlignakTest):
+class Test_Broker_Bad_Start(template_Daemon_Bad_Start, unittest.TestCase):
     daemon_cls = Broker
 
 
-class Test_Scheduler_Bad_Start(template_Daemon_Bad_Start, AlignakTest):
+class Test_Scheduler_Bad_Start(template_Daemon_Bad_Start, unittest.TestCase):
     daemon_cls = Alignak
 
 
-class Test_Poller_Bad_Start(template_Daemon_Bad_Start, AlignakTest):
+class Test_Poller_Bad_Start(template_Daemon_Bad_Start, unittest.TestCase):
     daemon_cls = Poller
 
 
-class Test_Reactionner_Bad_Start(template_Daemon_Bad_Start, AlignakTest):
+class Test_Reactionner_Bad_Start(template_Daemon_Bad_Start, unittest.TestCase):
     daemon_cls = Reactionner
 
 
-class Test_Arbiter_Bad_Start(template_Daemon_Bad_Start, AlignakTest):
+class Test_Arbiter_Bad_Start(template_Daemon_Bad_Start, unittest.TestCase):
 
     daemon_cls = Arbiter
 

--- a/test/test_scheduler_init.py
+++ b/test/test_scheduler_init.py
@@ -67,6 +67,7 @@ daemons_config = {
 class testSchedulerInit(AlignakTest):
     def setUp(self):
         time_hacker.set_real_time()
+        self.arb_proc = None
 
     def create_daemon(self):
         cls = Alignak
@@ -85,7 +86,7 @@ class testSchedulerInit(AlignakTest):
         return data
 
     def tearDown(self):
-        proc = getattr(self, 'arb_proc', None)
+        proc = self.arb_proc
         if proc:
             self._get_subproc_data(proc)  # so to terminate / wait it..
 
@@ -110,7 +111,7 @@ class testSchedulerInit(AlignakTest):
             assert(fun in reg_list)
 
         # Launch an arbiter so that the scheduler get a conf and init
-        args = ["../alignak/bin/alignak_arbiter.py", "-c", daemons_config[Arbiter][0], "-d"]
+        args = ["../alignak/bin/alignak_arbiter.py", "-c", daemons_config[Arbiter][0]]
         proc = self.arb_proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         # Ok, now the conf

--- a/test/test_scheduler_init.py
+++ b/test/test_scheduler_init.py
@@ -115,7 +115,10 @@ class testSchedulerInit(AlignakTest):
         proc = self.arb_proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         # Ok, now the conf
-        d.wait_for_initial_conf(timeout=20)
+        for i in range(20):
+            d.wait_for_initial_conf(timeout=1)
+            if d.new_conf:
+                break
         self.assertTrue(d.new_conf)
 
         d.setup_new_conf()


### PR DESCRIPTION
Basically: join the main http thread (and in it join all the http client threads) when stopping an alignak daemon, so that no http thread is left running while everything is closed (which can, and have already, be harmful) .

\+ some cleaning 
\+ some better logs 
\+ few fixes related to http.