### PR TITLE
Enh: Tests - Update pep8 command and add symlink to keep modules test…

### DIFF
--- a/test/jenkins/new_runtest.sh
+++ b/test/jenkins/new_runtest.sh
@@ -380,6 +380,9 @@ function main {
     # Clean previous symlinks
     find etc/ -maxdepth 1 -type l -exec rm {} \;
 
+    # Some module still use the shinken_* file so add a symlink for now
+    cp etc/alignak_1r_1h_1s.cfg etc/shinken_1r_1h_1s.cfg
+
     # Init Count for coverage
     COUNT=1
 
@@ -422,7 +425,7 @@ function main {
     if [[ $PEP8 == "PEP8" ]]; then
         echo "Pep8 Checking"
         cd $ALIGNAKDIR
-        ${PYTHONTOOLS}/pep8 --max-line-length=100 --ignore=E303 alignak > "test/$RESULTSDIR/pep8.txt"
+        ${PYTHONTOOLS}/pep8 --max-line-length=100 --ignore=E303,E302,E301,E241 --exclude='*.pyc' alignak/* > "test/$RESULTSDIR/pep8.txt"
         cd -
     fi
 


### PR DESCRIPTION
…s fine

Needed for Jenkins actually because modules still have shinken_*.cfg hardcoded in test. 