### PR TITLE
Fix: Tests - Path to shinken_arbiter in test_sslv3

### DIFF
--- a/test/test_sslv3_disabled.py
+++ b/test/test_sslv3_disabled.py
@@ -87,7 +87,7 @@ class testSchedulerInit(AlignakTest):
         d.load_modules_manager()
 
         # Launch an arbiter so that the scheduler get a conf and init
-        subprocess.Popen(["../bin/alignak-arbiter.py", "-c", daemons_config[Arbiter][0], "-d"])
+        subprocess.Popen(["../alignak/bin/alignak_arbiter.py", "-c", daemons_config[Arbiter][0], "-d"])
         if not hasattr(ssl, 'SSLContext'):
             print 'BAD ssl version for testing, bailing out'
             return


### PR DESCRIPTION
Travis was not failing because it skips it.