### PR TITLE
Fix: get name in daemon

### DIFF
--- a/alignak/objects/arbiterlink.py
+++ b/alignak/objects/arbiterlink.py
@@ -61,8 +61,6 @@ class ArbiterLink(SatelliteLink):
         'port':            IntegerProp(default=7770),
     })
 
-    def get_name(self):
-        return self.arbiter_name
 
     def get_config(self):
         return self.con.get('get_config')

--- a/alignak/objects/brokerlink.py
+++ b/alignak/objects/brokerlink.py
@@ -54,8 +54,6 @@ class BrokerLink(SatelliteLink):
         'port': IntegerProp(default=7772, fill_brok=['full_status']),
     })
 
-    def get_name(self):
-        return self.broker_name
 
     def register_to_my_realm(self):
         self.realm.brokers.append(self)

--- a/alignak/objects/pollerlink.py
+++ b/alignak/objects/pollerlink.py
@@ -63,9 +63,6 @@ class PollerLink(SatelliteLink):
         'poller_tags':  ListProp(default=['None'], to_send=True),
     })
 
-    def get_name(self):
-        return getattr(self, 'poller_name', 'UNNAMED-POLLER')
-
     def register_to_my_realm(self):
         self.realm.pollers.append(self)
 

--- a/alignak/objects/reactionnerlink.py
+++ b/alignak/objects/reactionnerlink.py
@@ -60,9 +60,6 @@ class ReactionnerLink(SatelliteLink):
         'reactionner_tags':      ListProp(default=['None'], to_send=True),
     })
 
-    def get_name(self):
-        return self.reactionner_name
-
     def register_to_my_realm(self):
         self.realm.reactionners.append(self)
 

--- a/alignak/objects/receiverlink.py
+++ b/alignak/objects/receiverlink.py
@@ -63,9 +63,6 @@ class ReceiverLink(SatelliteLink):
                                                          fill_brok=['full_status'], to_send=True),
     })
 
-    def get_name(self):
-        return self.receiver_name
-
     def register_to_my_realm(self):
         self.realm.receivers.append(self)
 

--- a/alignak/objects/satellitelink.py
+++ b/alignak/objects/satellitelink.py
@@ -110,6 +110,10 @@ class SatelliteLink(Item):
             except Exception:
                 pass
 
+    def get_name(self):
+        return getattr(self,
+                       "{0}_name".format(self.get_my_type()),
+                       "Unnamed {0}".format(self.get_my_type()))
 
     def set_arbiter_satellitemap(self, satellitemap):
         """

--- a/alignak/objects/schedulerlink.py
+++ b/alignak/objects/schedulerlink.py
@@ -72,9 +72,6 @@ class SchedulerLink(SatelliteLink):
         'push_flavor': IntegerProp(default=0),
     })
 
-    def get_name(self):
-        return self.scheduler_name
-
     def run_external_commands(self, commands):
         if self.con is None:
             self.create_connection()

--- a/test/test_get_name.py
+++ b/test/test_get_name.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors
+#
+# This file is part of Alignak.
+#
+# Alignak is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Alignak is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest2 as unittest
+from alignak.objects.arbiterlink import ArbiterLink
+from alignak.objects.schedulerlink import SchedulerLink
+from alignak.objects.brokerlink import BrokerLink
+from alignak.objects.reactionnerlink import ReactionnerLink
+from alignak.objects.receiverlink import ReceiverLink
+from alignak.objects.pollerlink import PollerLink
+
+class template_DaemonLink_get_name():
+    def get_link(self):
+        cls = self.daemon_link
+        return cls({})
+
+    def test_get_name(self):
+        link = self.get_link()
+        try:
+            self.assertEquals("Unnamed {0}".format(self.daemon_link.my_type), link.get_name())
+        except AttributeError:
+            self.assertTrue(False, "get_name should not raise AttributeError")
+
+
+class Test_ArbiterLink_get_name(template_DaemonLink_get_name, unittest.TestCase):
+    daemon_link = ArbiterLink
+
+class Test_SchedulerLink_get_name(template_DaemonLink_get_name, unittest.TestCase):
+    daemon_link = SchedulerLink
+
+
+class Test_BrokerLink_get_name(template_DaemonLink_get_name, unittest.TestCase):
+    daemon_link = BrokerLink
+
+
+class Test_ReactionnerLink_get_name(template_DaemonLink_get_name, unittest.TestCase):
+    daemon_link = ReactionnerLink
+
+
+class Test_ReceiverLink_get_name(template_DaemonLink_get_name, unittest.TestCase):
+    daemon_link = ReceiverLink
+
+
+class Test_PollerLink_get_name(template_DaemonLink_get_name, unittest.TestCase):
+    daemon_link = PollerLink
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
get_name raise an AttributeError when called too early,

It can  happen in regenerator functions manage_initial_*sattelite*_status_brok. 

I spotted that by tring to fix LS test in Jenkins :)