### PR TITLE
Enh: Bind timehacker to class so that it is unique

### DIFF
--- a/test/alignak_test.py
+++ b/test/alignak_test.py
@@ -128,9 +128,6 @@ class TimeHacker(object):
             self.in_real_time = True
 
 
-#Time hacking for every test!
-time_hacker = TimeHacker()
-time_hacker.set_my_time()
 
 
 class Pluginconf(object):
@@ -139,11 +136,12 @@ class Pluginconf(object):
 
 
 class AlignakTest(unittest.TestCase):
+    time_hacker = TimeHacker()
     def setUp(self):
         self.setup_with_file('etc/alignak_1r_1h_1s.cfg')
 
     def setup_with_file(self, path):
-        time_hacker.set_my_time()
+        self.time_hacker.set_my_time()
         self.print_header()
         # i am arbiter-like
         self.broks = {}
@@ -473,6 +471,8 @@ class AlignakTest(unittest.TestCase):
 
 ShinkenTest = AlignakTest
 
+#Time hacking for every test!
+time_hacker = AlignakTest.time_hacker
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It is imported several time in module testing so that it does not set my time / realtime properly.

Found this while digging test failures on jenkins (livestatus wait query)