### PR TITLE
Fix unknown realm in realm_members  attribute

### DIFF
--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -1914,7 +1914,8 @@ class Config(Item):
 
         for x in ('hosts', 'hostgroups', 'contacts', 'contactgroups', 'notificationways',
                   'escalations', 'services', 'servicegroups', 'timeperiods', 'commands',
-                  'hostsextinfo', 'servicesextinfo', 'checkmodulations', 'macromodulations'):
+                  'hostsextinfo', 'servicesextinfo', 'checkmodulations', 'macromodulations',
+                  'realms'):
             if self.read_config_silent == 0:
                 logger.info('Checking %s...', x)
 

--- a/alignak/objects/realm.py
+++ b/alignak/objects/realm.py
@@ -97,7 +97,7 @@ class Realm(Itemgroup):
         return self.realm_members
 
     def add_string_member(self, member):
-        self.realm_members += ',' + member
+        self.realm_members.append(member)
 
     def get_realm_members(self):
         if self.has('realm_members'):
@@ -123,7 +123,7 @@ class Realm(Itemgroup):
             if self.has('members'):
                 return self.members
             else:
-                return ''
+                return []
 
         # Ok, not a loop, we tag it and continue
         self.rec_tag = True
@@ -133,13 +133,13 @@ class Realm(Itemgroup):
             p = realms.find_by_name(p_mbr.strip())
             if p is not None:
                 value = p.get_realms_by_explosion(realms)
-                if value is not None:
+                if len(value) > 0:
                     self.add_string_member(value)
 
         if self.has('members'):
             return self.members
         else:
-            return ''
+            return []
 
     def get_all_subs_satellites_by_type(self, sat_type):
         r = copy.copy(getattr(self, sat_type))
@@ -367,6 +367,8 @@ class Realms(Itemgroups):
                 new_mbr = self.find_by_name(mbr)
                 if new_mbr is not None:
                     new_mbrs.append(new_mbr)
+                else:
+                    p.add_string_unknown_member(mbr)
             # We find the id, we replace the names
             p.realm_members = new_mbrs
 

--- a/test/etc/bad_realm_conf/alignak-specific.cfg
+++ b/test/etc/bad_realm_conf/alignak-specific.cfg
@@ -122,6 +122,7 @@ define realm{
 
 define realm{
        realm_name	Realm1
+       realm_members UNKNOWNREALM
        default 1
 }
 

--- a/test/test_bad_realm_conf.py
+++ b/test/test_bad_realm_conf.py
@@ -59,6 +59,7 @@ class TestBadRealmConf(AlignakTest):
         self.assertFalse(self.conf.conf_is_correct)
         self.assert_any_log_match(" Error : More than one realm are set to the default realm")
         self.assert_any_log_match("\[host::.*\] the host .* got an invalid realm")
+        self.assert_any_log_match("\[itemgroup::.*\] as realm, got unknown member UNKNOWNREALM")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

Realm members were not checked (no call to is_correct) so that unconsistent members where not raised

Parsing is now better. Need this to be merged so that I can sync it with Pylint branch and Pylint this file (as I found this bug while doing it)