### PR TITLE
Enh: Test - Add unittest call to main

### DIFF
--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -111,3 +111,7 @@ class Test_Alignak_Http_Client(unittest.TestCase):
 class Test_Alignak_Http_Client_With_CherrPy_Backend(Test_Alignak_Http_Client):
 
     http_backend = 'cherrypy'  # ho well
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If __name__ == ... was missing to launch the test with python test_http_client.py
