### PR TITLE
Enh pylint w0614

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - nosetests -xv --process-restartworker --processes=1 --process-timeout=300  --with-coverage --cover-package=alignak
   - coverage combine
   - cd .. && pep8 --max-line-length=100 --exclude='*.pyc' alignak/*
-  - pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 -r no alignak/*
+  - pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 -r no alignak/*
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then ./test/test_all_setup.sh; fi
 # specific call to launch coverage data into coveralls.io
 after_success:

--- a/alignak/webui/bottlewebui.py
+++ b/alignak/webui/bottlewebui.py
@@ -2,6 +2,7 @@
 to avoid code duplication
 
 """
+# pylint: disable=W0614
 from .bottlecore import *
 
 


### PR DESCRIPTION
Only warning were in bottlewebui, I skip it as we will rewrite this


```
:unused-wildcard-import (W0614): *Unused import %s from wildcard import*
  Used when an imported module or variable is not used from a 'from X import *'
  style import. This message belongs to the variables checker.

```