### PR TITLE
Enh pylint w0107

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - nosetests -xv --process-restartworker --processes=1 --process-timeout=300  --with-coverage --cover-package=alignak
   - coverage combine
   - cd .. && pep8 --max-line-length=100 --exclude='*.pyc' alignak/*
-  - pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 -r no alignak/*
+  - pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 --enable=W0107 -r no alignak/*
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then ./test/test_all_setup.sh; fi
 # specific call to launch coverage data into coveralls.io
 after_success:

--- a/alignak/util.py
+++ b/alignak/util.py
@@ -1037,7 +1037,6 @@ def get_key_value_sequence(entry, default_value=None):
                 got_xy = (len(ns) != 1)
             except NodeSetParseRangeError:
                 return (None, GET_KEY_VALUE_SEQUENCE_ERROR_NODE)
-                pass  # go in the next key
 
         # Now we've got our couples of X-Y. If no void,
         # we were with a "key generator"


### PR DESCRIPTION
```
:unnecessary-pass (W0107): *Unnecessary pass statement*
  Used when a "pass" statement that can be avoided is encountered. This message
  belongs to the basic checker.

```