### PR TITLE
Enh pylint rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - nosetests -xv --process-restartworker --processes=1 --process-timeout=300  --with-coverage --cover-package=alignak
   - coverage combine
   - cd .. && pep8 --max-line-length=100 --exclude='*.pyc' alignak/*
-  - pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 --enable=W0107 --enable=W0141 -r no alignak/*
+  - pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 --enable=W0107 --enable=C0204 --enable=W0109  --enable=W0223  --enable=W0311  --enable=W0404  --enable=W0623  --enable=W0633 --enable=W0640  --enable=W0105 --enable=W0141 -r no alignak/*
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then ./test/test_all_setup.sh; fi
 # specific call to launch coverage data into coveralls.io
 after_success:

--- a/alignak/autoslots.py
+++ b/alignak/autoslots.py
@@ -57,13 +57,13 @@ class AutoSlots(type):
 
     """
 
-    def __new__(cls, name, bases, dct):
+    def __new__(mcs, name, bases, dct):
         """Called when we create a new Class
         Some properties names are not allowed in __slots__ like 2d_coords of
         Host, so we must tag them in properties with no_slots
 
-        :param cls: AutoSlots
-        :type cls: object
+        :param mcs: AutoSlots
+        :type mcs: object
         :param name: string of the Class (like Service)
         :type name: str
         :param bases: Classes of which Class inherits (like SchedulingItem)
@@ -85,4 +85,4 @@ class AutoSlots(type):
             slots.update((p for p in props
                           if not props[p].no_slots))
         dct['__slots__'] = tuple(slots)
-        return type.__new__(cls, name, bases, dct)
+        return type.__new__(mcs, name, bases, dct)

--- a/alignak/basemodule.py
+++ b/alignak/basemodule.py
@@ -64,19 +64,6 @@ import alignak.http_daemon
 from alignak.log import logger
 from alignak.misc.common import setproctitle
 
-# TODO: use a class for defining the module "properties" instead of
-# plain dict??  Like:
-"""
-class ModuleProperties(object):
-    def __init__(self, type, phases, external=False)
-        self.type = type
-        self.phases = phases
-        self.external = external
-"""
-# and  have the new modules instanciate this like follow:
-"""
-properties = ModuleProperties('the_module_type', the_module_phases, is_mod_ext)
-"""
 
 # The `properties dict defines what the module can do and
 # if it's an external module or not.

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -66,7 +66,6 @@ import os
 import time
 import traceback
 import socket
-import traceback
 import cStringIO
 import cPickle
 import copy

--- a/alignak/daemons/schedulerdaemon.py
+++ b/alignak/daemons/schedulerdaemon.py
@@ -266,24 +266,6 @@ class IForArbiter(IArb):
         super(IForArbiter, self).wait_new_conf()
 
 
-"""
-class Injector(Interface):
-    # A broker ask us broks
-    def inject(self, bincode):
-
-        # first we need to get a real code object
-        import marshal
-        print "Calling Inject mode"
-        code = marshal.loads(bincode)
-        result = None
-        exec code
-        try:
-            return result
-        except NameError, exp:
-            return None
-"""
-
-
 class Alignak(BaseSatellite):
     """Scheduler class. Referenced as "app" in most Interface
 

--- a/alignak/dependencynode.py
+++ b/alignak/dependencynode.py
@@ -683,8 +683,8 @@ class DependencyNodeFactory(object):
                 host_expr = elts[0]
                 filters.extend(self.get_host_filters(host_expr))
                 items = hosts.find_by_filter(filters)
-        except re.error, e:
-            error = "Business rule uses invalid regex %s: %s" % (pattern, e)
+        except re.error, regerr:
+            error = "Business rule uses invalid regex %s: %s" % (pattern, regerr)
         else:
             if not items:
                 error = "Business rule got an empty result for pattern %s" % pattern

--- a/alignak/eventhandler.py
+++ b/alignak/eventhandler.py
@@ -76,7 +76,6 @@ class EventHandler(Action):
         'output':         StringProp(default=''),
         'long_output':    StringProp(default=''),
         't_to_go':        StringProp(default=0),
-        'check_time':     StringProp(default=0),
         'execution_time': FloatProp(default=0),
         'u_time':         FloatProp(default=0.0),
         's_time':         FloatProp(default=0.0),

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2583,7 +2583,7 @@ class Config(Item):
                               (o["host_name"], o["service_description"]))
             elif hasattr(container, "name_property"):
                 np = container.name_property
-                objs = sorted(objs, key=lambda o: getattr(o, np, ''))
+                objs = sorted(objs, key=lambda o, prop=np: getattr(o, prop, ''))
             dmp[category] = objs
 
         if f is None:

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -947,9 +947,9 @@ class Service(SchedulingItem):
                                                                               key_value[key]))
                     if hasattr(self, 'service_dependencies'):
                         for i, sd in enumerate(new_s.service_dependencies):
-                                new_s.service_dependencies[i] = sd.replace(
-                                    '$' + key + '$', key_value[key]
-                                )
+                            new_s.service_dependencies[i] = sd.replace(
+                                '$' + key + '$', key_value[key]
+                            )
                 # And then add in our list this new service
                 duplicates.append(new_s)
         else:

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -1677,7 +1677,7 @@ class Services(Items):
             item = self.index_item(item)
         self.items[item.id] = item
 
-    def add_partial_service(self, item, index=True, var_tuple=None):
+    def add_partial_service(self, item, index=True, var_tuple=tuple()):
         """Add a partial service.
         ie : A service that does not have service_description or host_name/host_group
         We have to index them differently and try to inherit from our template to get one
@@ -1692,7 +1692,7 @@ class Services(Items):
         :type var_tuple: tuple
         :return: None
         """
-        if var_tuple is None:
+        if len(var_tuple) == 0:
             return
 
         objcls, hname, hgname, sdesc, in_file = var_tuple

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -339,6 +339,14 @@ class BaseSatellite(Daemon):
         self.external_commands = []
         return res
 
+    def do_loop_turn(self):
+        """Abstract method for satellite loop turn.
+        It must be overridden by class inheriting from Daemon
+
+        :return: None
+        """
+        raise NotImplementedError()
+
 
 class Satellite(BaseSatellite):
     """Satellite class.

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -750,20 +750,6 @@ class Satellite(BaseSatellite):
                 except NotWorkerMod:
                     to_del.append(mod)
                     break
-            """
-            # Try to really adjust load if necessary
-            if self.get_max_q_len(mod) > self.max_q_size:
-                if len(self.q_by_mod[mod]) >= self.max_workers:
-                    logger.info("Cannot add a new %s worker, even if load is high. "
-                                "Consider changing your max_worker parameter") % mod
-                else:
-                    try:
-                        self.create_and_launch_worker(module_name=mod)
-                    # Maybe this modules is not a true worker one.
-                    # if so, just delete if from q_by_mod
-                    except NotWorkerMod:
-                        to_del.append(mod)
-            """
 
         for mod in to_del:
             logger.debug("[%s] The module %s is not a worker one, "

--- a/alignak/satellitelink.py
+++ b/alignak/satellitelink.py
@@ -20,8 +20,9 @@
 
 """alignak.satellitelink is deprecated. Please use alignak.objects.satellitelink now."""
 
+# TODO: make_deprecated is not found
 from alignak.old_daemon_link import deprecation, make_deprecated
-"""TODO: make_deprecated is not found"""
+
 
 deprecation(__doc__)
 


### PR DESCRIPTION
```
:bad-mcs-classmethod-argument (C0204): *Metaclass class method %s should have %s as first argument*
  Used when a metaclass class method has a first argument named differently than
  the value specified in valid-metaclass-classmethod-first-arg option (default
  to "mcs"), recommended to easily differentiate them from regular instance
  methods. This message belongs to the classes checker.

:duplicate-key (W0109): *Duplicate key %r in dictionary*
  Used when a dictionary expression binds the same key multiple times. This
  message belongs to the basic checker.

:abstract-method (W0223): *Method %r is abstract in class %r but is not overridden*
  Used when an abstract method (i.e. raise NotImplementedError) is not
  overridden in concrete class. This message belongs to the classes checker.

:bad-indentation (W0311): *Bad indentation. Found %s %s, expected %s*
  Used when an unexpected number of indentation's tabulations or spaces has been
  found. This message belongs to the format checker.

:reimported (W0404): *Reimport %r (imported line %s)*
  Used when a module is reimported multiple times. This message belongs to the
  imports checker.

:redefine-in-handler (W0623): *Redefining name %r from %s in exception handler*
  Used when an exception handler assigns the exception to an existing name This
  message belongs to the variables checker.

:unpacking-non-sequence (W0633): *Attempting to unpack a non-sequence%s*
  Used when something which is not a sequence is used in an unpack assignment
  This message belongs to the variables checker.

:cell-var-from-loop (W0640): *Cell variable %s defined in loop*
  A variable used in a closure is defined in a loop. This will result in all
  closures using the same value for the closed-over variable. This message
  belongs to the variables checker.

:pointless-string-statement (W0105): *String statement has no effect*
  Used when a string is used as a statement (which of course has no effect).
  This is a particular case of W0104 with its own message so you can easily
  disable it if you're using those strings as documentation, instead of
  comments. This message belongs to the basic checker.
```

For W0640 I could have ignored it but I found a good workaround here : http://stackoverflow.com/questions/25314547/cell-var-from-loop-warning-from-pylint