### PR TITLE
Enh: Revert datamanager constant rename. Will handle it with log etc

### DIFF
--- a/alignak/misc/datamanager.py
+++ b/alignak/misc/datamanager.py
@@ -682,4 +682,5 @@ class DataManager(object):
         res = [s for s in obj.host.services if s.state_id != 0 and s != obj]
         return res
 
-DATA_MGR = DataManager()
+# pylint: disable=C0103
+datamgr = DataManager()

--- a/test/alignak_modules.py
+++ b/test/alignak_modules.py
@@ -31,7 +31,7 @@ import sys # not here used but "sub-"imported by livestatus test.. (to be correc
 from alignak.modulesctx import modulesctx
 from alignak.objects.module import Module
 from alignak.modulesmanager import ModulesManager
-from alignak.misc.datamanager import DATA_MGR
+from alignak.misc.datamanager import datamgr
 from alignak.log import logger
 
 #
@@ -129,8 +129,8 @@ class AlignakModulesTest(AlignakTest):
             print "errors during load", s
         del self.livestatus_broker.debug_output
         self.livestatus_broker.rg = LiveStatusRegenerator()
-        self.livestatus_broker.datamgr = DATA_MGR
-        DATA_MGR.load(self.livestatus_broker.rg)
+        self.livestatus_broker.datamgr = datamgr
+        datamgr.load(self.livestatus_broker.rg)
         self.livestatus_broker.query_cache = LiveStatusQueryCache()
         if not needcache:
             self.livestatus_broker.query_cache.disable()


### PR DESCRIPTION
Better to handle all the case with var=obj() in module the same way. Datamanager rename will break a lot of module (webui, LS). Let ignore the error for now.