### PR TITLE
Replace cpickle in brok by ujson because better performances (between…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pbr
 termcolor==1.1.0
 setproctitle
 ordereddict==1.1
+ujson

--- a/test/test_external_commands.py
+++ b/test/test_external_commands.py
@@ -54,7 +54,7 @@
 from alignak_test import *
 from alignak.external_command import ExternalCommandManager
 import os
-import cPickle
+import ujson
 
 
 class TestConfig(AlignakTest):
@@ -292,25 +292,25 @@ class TestConfig(AlignakTest):
         # unknown_host_check_result_brok
         excmd = '[1234567890] PROCESS_HOST_CHECK_RESULT;test_host_0;2;Bob is not happy'
         expected = {'time_stamp': 1234567890, 'return_code': '2', 'host_name': 'test_host_0', 'output': 'Bob is not happy', 'perf_data': None}
-        result = cPickle.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
+        result = ujson.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
         self.assertEqual(expected, result)
 
         # unknown_host_check_result_brok with perfdata
         excmd = '[1234567890] PROCESS_HOST_CHECK_RESULT;test_host_0;2;Bob is not happy|rtt=9999'
         expected = {'time_stamp': 1234567890, 'return_code': '2', 'host_name': 'test_host_0', 'output': 'Bob is not happy', 'perf_data': 'rtt=9999'}
-        result = cPickle.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
+        result = ujson.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
         self.assertEqual(expected, result)
 
         # unknown_service_check_result_brok
         excmd = '[1234567890] PROCESS_HOST_CHECK_RESULT;host-checked;0;Everything OK'
         expected = {'time_stamp': 1234567890, 'return_code': '0', 'host_name': 'host-checked', 'output': 'Everything OK', 'perf_data': None}
-        result = cPickle.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
+        result = ujson.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
         self.assertEqual(expected, result)
 
         # unknown_service_check_result_brok with perfdata
         excmd = '[1234567890] PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_0;1;Bobby is not happy|rtt=9999;5;10;0;10000'
         expected = {'host_name': 'test_host_0', 'time_stamp': 1234567890, 'service_description': 'test_ok_0', 'return_code': '1', 'output': 'Bobby is not happy', 'perf_data': 'rtt=9999;5;10;0;10000'}
-        result = cPickle.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
+        result = ujson.loads(ExternalCommandManager.get_unknown_check_result_brok(excmd).data)
         self.assertEqual(expected, result)
 
     def test_change_and_reset_modattr(self):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -48,7 +48,7 @@ Test alignak.logging
 import sys
 import os
 import time
-import cPickle
+import ujson
 from cStringIO import StringIO
 
 from tempfile import NamedTemporaryFile
@@ -139,7 +139,7 @@ class LogCollectMixin:
         for obj in collector.list:
             self.assertIsInstance(obj, Brok)
             self.assertEqual(obj.type, 'log')
-            data = cPickle.loads(obj.data)
+            data = ujson.loads(obj.data)
             self.assertEqual(data.keys(), ['log'])
             yield data['log']
 


### PR DESCRIPTION
… 3 times to 10 times)

Test

Add function to allow ujson or cpickle depends on type

Fix broks type to use ujson

Fix unit test

Fix unit test

Clean