### PR TITLE
Enh: Remove http_backend parameter, not used anymore

### DIFF
--- a/etc/alignak.cfg
+++ b/etc/alignak.cfg
@@ -129,9 +129,6 @@ server_cert=/etc/alignak/certs/server.cert
 server_key=/etc/alignak/certs/server.key
 hard_ssl_name_check=0
 
-# If cherrypy3 is not available, it will fail back to swsgiref
-http_backend=auto
-
 
 # kernel.alignak.io communication channel. Create an account to http://shinken.io
 # and look at your profile to fill this.

--- a/etc/daemons/brokerd.ini
+++ b/etc/daemons/brokerd.ini
@@ -27,7 +27,6 @@ use_ssl=0
 #server_cert=/etc/alignak/certs/server.cert
 #server_key=/etc/alignak/certs/server.key
 #hard_ssl_name_check=0
-http_backend=auto
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting

--- a/etc/daemons/pollerd.ini
+++ b/etc/daemons/pollerd.ini
@@ -17,7 +17,6 @@ pidfile=%(workdir)s/pollerd.pid
 #-- Network configuration
 # host=0.0.0.0
 # port=7771
-# http_backend=auto
 # idontcareaboutsecurity=0
 
 #-- SSL configuration --

--- a/etc/daemons/reactionnerd.ini
+++ b/etc/daemons/reactionnerd.ini
@@ -21,7 +21,6 @@ use_ssl=0
 #server_cert=/etc/alignak/certs/server.cert
 #server_key=/etc/alignak/certs/server.key
 #hard_ssl_name_check=0
-http_backend=auto
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting

--- a/etc/daemons/receiverd.ini
+++ b/etc/daemons/receiverd.ini
@@ -21,7 +21,6 @@ use_ssl=0
 #server_cert=/etc/alignak/certs/server.cert
 #server_key=/etc/alignak/certs/server.key
 #hard_ssl_name_check=0
-http_backend=auto
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting

--- a/etc/daemons/schedulerd.ini
+++ b/etc/daemons/schedulerd.ini
@@ -26,7 +26,6 @@ use_ssl=0
 #server_cert=/etc/alignak/certs/server.cert
 #server_key=/etc/alignak/certs/server.key
 hard_ssl_name_check=0
-http_backend=auto
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting

--- a/test/etc/netkit/conf-01/alignak-specific.cfg
+++ b/test/etc/netkit/conf-01/alignak-specific.cfg
@@ -175,8 +175,6 @@ define module{
     #  ***** Advanced options. Do not touch it if you don't
     #  know what you are doing  ****
 
-    #  ; can be also: wsgiref, cherrypy, paste, tornado, twisted
-    #  ; or gevent. auto means it tries to find the best available in the system.
 
     #  Maybe the WebUI is behind a web server which has already authentified the user
     #  So let's use the Remote_user variable

--- a/test/etc/netkit/conf-02/alignak-specific.cfg
+++ b/test/etc/netkit/conf-02/alignak-specific.cfg
@@ -181,9 +181,6 @@ define module{
     #  ***** Advanced options. Do not touch it if you don't
     #  know what you are doing  ****
 
-    #  ; can be also: wsgiref, cherrypy, paste, tornado, twisted
-    #  ; or gevent. auto means it tries to find the best available in the system.
-
     #  Maybe the WebUI is behind a web server which has already authentified the user
     #  So let's use the Remote_user variable
     #  See documentation for an example of the configuration of Apache in front of the WebUI


### PR DESCRIPTION
Forgot config parameter when rewriting HTTPD