### PR TITLE
Fix: pylint & logilab annoying pkgutil output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 # so we must combine them in the end
 script:
   - cd test
+  - touch $(python -c 'import logilab; print(logilab.__path__[0])')/__init__.py
   - pip freeze  # so to help eventual debug: know what exact versions are in use can be rather useful.
   - nosetests -xv --process-restartworker --processes=1 --process-timeout=300  --with-coverage --cover-package=alignak
   - coverage combine

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,7 +6,7 @@ coveralls==0.5
 nose-cov==1.6
 coverage==3.7.1
 nose==1.3.7
-pylint==1.4.1
+pylint==1.4.4
 pep8==1.5.7
 pep257
 freezegun


### PR DESCRIPTION
getting numerous of these lines:

/opt/python/2.7.9/lib/python2.7/pkgutil.py:186: ImportWarning: Not importing directory '/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/logilab': missing __init__.py
  file, filename, etc = imp.find_module(subname, path)

See:
https://github.com/klen/python-mode/pull/598
http://stackoverflow.com/questions/25466626/how-do-i-get-pylint-to-find-namespace-packages
etc...