### PR TITLE
Fix #213: unittest pending deprecation

### DIFF
--- a/test/alignak_test.py
+++ b/test/alignak_test.py
@@ -128,15 +128,18 @@ class TimeHacker(object):
             self.in_real_time = True
 
 
-
-
 class Pluginconf(object):
     pass
 
 
-
 class AlignakTest(unittest.TestCase):
+
     time_hacker = TimeHacker()
+
+    if sys.version_info < (2, 7):
+        def assertRegex(self, *args, **kwargs):
+            return self.assertRegexpMatches(*args, **kwargs)
+
     def setUp(self):
         self.setup_with_file(['etc/alignak_1r_1h_1s.cfg'], add_default=False)
 

--- a/test/test_get_name.py
+++ b/test/test_get_name.py
@@ -26,6 +26,7 @@ from alignak.objects.reactionnerlink import ReactionnerLink
 from alignak.objects.receiverlink import ReceiverLink
 from alignak.objects.pollerlink import PollerLink
 
+
 class template_DaemonLink_get_name():
     def get_link(self):
         cls = self.daemon_link
@@ -34,7 +35,7 @@ class template_DaemonLink_get_name():
     def test_get_name(self):
         link = self.get_link()
         try:
-            self.assertEquals("Unnamed {0}".format(self.daemon_link.my_type), link.get_name())
+            self.assertEqual("Unnamed {0}".format(self.daemon_link.my_type), link.get_name())
         except AttributeError:
             self.assertTrue(False, "get_name should not raise AttributeError")
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -191,7 +191,7 @@ class LogCollectMixin:
         for i, length in enumerate(lenlist):
             self.assertEqual(len(loglist[i]), length)
             if length != 0:
-                self.assertRegexpMatches(loglist[i][0], patterns[i])
+                self.assertRegex(loglist[i][0], patterns[i])
         return loglist
 
 


### PR DESCRIPTION
/home/travis/build/gst/alignak/test/test_logging.py:194: PendingDeprecationWarning: Please use assertRegex instead.
  self.assertRegexpMatches(loglist[i][0], patterns[i])
