### PR TITLE
Disable verbose coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_success:
   # to get coverage data with relative paths and not absolute we have to
   # execute coveralls from the base directory of the project,
   # so we need to move the .coverage file here :
-  mv test/.coverage . && coveralls --rcfile=test/.coveragerc -v
+  mv test/.coverage . && coveralls --rcfile=test/.coveragerc
 
 notifications:
   webhooks:


### PR DESCRIPTION
no (more) necessary.

was only used for when coveralls.io was we've setup coveralls.io configuration I think / remember.

As it pollutes the travis output I prefer to disable it.