### PR TITLE
Enh: Remove shebang on non executable python files

### DIFF
--- a/alignak/__init__.py
+++ b/alignak/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/acknowledge.py
+++ b/alignak/acknowledge.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/arbiterlink.py
+++ b/alignak/arbiterlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/autoslots.py
+++ b/alignak/autoslots.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/basemodule.py
+++ b/alignak/basemodule.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/bin/__init__.py
+++ b/alignak/bin/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/borg.py
+++ b/alignak/borg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/brok.py
+++ b/alignak/brok.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/brokerlink.py
+++ b/alignak/brokerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/check.py
+++ b/alignak/check.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/commandcall.py
+++ b/alignak/commandcall.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/comment.py
+++ b/alignak/comment.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/complexexpression.py
+++ b/alignak/complexexpression.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/contactdowntime.py
+++ b/alignak/contactdowntime.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/daemons/__init__.py
+++ b/alignak/daemons/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/daemons/brokerdaemon.py
+++ b/alignak/daemons/brokerdaemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/daemons/pollerdaemon.py
+++ b/alignak/daemons/pollerdaemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/daemons/reactionnerdaemon.py
+++ b/alignak/daemons/reactionnerdaemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/daemons/receiverdaemon.py
+++ b/alignak/daemons/receiverdaemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/daemons/schedulerdaemon.py
+++ b/alignak/daemons/schedulerdaemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/daterange.py
+++ b/alignak/daterange.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/db.py
+++ b/alignak/db.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/db_mysql.py
+++ b/alignak/db_mysql.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/db_oracle.py
+++ b/alignak/db_oracle.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/db_sqlite.py
+++ b/alignak/db_sqlite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/dependencynode.py
+++ b/alignak/dependencynode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/downtime.py
+++ b/alignak/downtime.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/eventhandler.py
+++ b/alignak/eventhandler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/external_command.py
+++ b/alignak/external_command.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/graph.py
+++ b/alignak/graph.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/__init__.py
+++ b/alignak/http/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/broker_interface.py
+++ b/alignak/http/broker_interface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/cherrypy_extend.py
+++ b/alignak/http/cherrypy_extend.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/client.py
+++ b/alignak/http/client.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/daemon.py
+++ b/alignak/http/daemon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/generic_interface.py
+++ b/alignak/http/generic_interface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/receiver_interface.py
+++ b/alignak/http/receiver_interface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/http/scheduler_interface.py
+++ b/alignak/http/scheduler_interface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/load.py
+++ b/alignak/load.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/log.py
+++ b/alignak/log.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/macroresolver.py
+++ b/alignak/macroresolver.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/message.py
+++ b/alignak/message.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/misc/__init__.py
+++ b/alignak/misc/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/misc/common.py
+++ b/alignak/misc/common.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/misc/custom_module.py
+++ b/alignak/misc/custom_module.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/misc/datamanager.py
+++ b/alignak/misc/datamanager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/misc/filter.py
+++ b/alignak/misc/filter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/misc/logevent.py
+++ b/alignak/misc/logevent.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/misc/perfdata.py
+++ b/alignak/misc/perfdata.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/misc/regenerator.py
+++ b/alignak/misc/regenerator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/misc/sorter.py
+++ b/alignak/misc/sorter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/modulesctx.py
+++ b/alignak/modulesctx.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/modulesmanager.py
+++ b/alignak/modulesmanager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/notification.py
+++ b/alignak/notification.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/__init__.py
+++ b/alignak/objects/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/arbiterlink.py
+++ b/alignak/objects/arbiterlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/brokerlink.py
+++ b/alignak/objects/brokerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/businessimpactmodulation.py
+++ b/alignak/objects/businessimpactmodulation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/checkmodulation.py
+++ b/alignak/objects/checkmodulation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/command.py
+++ b/alignak/objects/command.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/contact.py
+++ b/alignak/objects/contact.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/contactgroup.py
+++ b/alignak/objects/contactgroup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/escalation.py
+++ b/alignak/objects/escalation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/hostdependency.py
+++ b/alignak/objects/hostdependency.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/hostescalation.py
+++ b/alignak/objects/hostescalation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/hostextinfo.py
+++ b/alignak/objects/hostextinfo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/hostgroup.py
+++ b/alignak/objects/hostgroup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/itemgroup.py
+++ b/alignak/objects/itemgroup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/macromodulation.py
+++ b/alignak/objects/macromodulation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/matchingitem.py
+++ b/alignak/objects/matchingitem.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/module.py
+++ b/alignak/objects/module.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/notificationway.py
+++ b/alignak/objects/notificationway.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/pack.py
+++ b/alignak/objects/pack.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/pollerlink.py
+++ b/alignak/objects/pollerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/reactionnerlink.py
+++ b/alignak/objects/reactionnerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/realm.py
+++ b/alignak/objects/realm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/receiverlink.py
+++ b/alignak/objects/receiverlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/resultmodulation.py
+++ b/alignak/objects/resultmodulation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/satellitelink.py
+++ b/alignak/objects/satellitelink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/schedulerlink.py
+++ b/alignak/objects/schedulerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/servicedependency.py
+++ b/alignak/objects/servicedependency.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/serviceescalation.py
+++ b/alignak/objects/serviceescalation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/serviceextinfo.py
+++ b/alignak/objects/serviceextinfo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/servicegroup.py
+++ b/alignak/objects/servicegroup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/objects/timeperiod.py
+++ b/alignak/objects/timeperiod.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/objects/trigger.py
+++ b/alignak/objects/trigger.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/old_daemon_link.py
+++ b/alignak/old_daemon_link.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/pollerlink.py
+++ b/alignak/pollerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/property.py
+++ b/alignak/property.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -*- mode: python ; coding: utf-8 -*-
 #

--- a/alignak/reactionnerlink.py
+++ b/alignak/reactionnerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/receiverlink.py
+++ b/alignak/receiverlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/satellitelink.py
+++ b/alignak/satellitelink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/schedulerlink.py
+++ b/alignak/schedulerlink.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #  Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/stats.py
+++ b/alignak/stats.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/trigger_functions.py
+++ b/alignak/trigger_functions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 #

--- a/alignak/util.py
+++ b/alignak/util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors

--- a/alignak/worker.py
+++ b/alignak/worker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors


### PR DESCRIPTION
Only bin/alignak* files should have it (non executable don't need them)

