### PR TITLE
Rewrite 95% function of util in average_percentile.

### DIFF
--- a/alignak/http/scheduler_interface.py
+++ b/alignak/http/scheduler_interface.py
@@ -25,7 +25,7 @@ import zlib
 
 from alignak.log import logger
 from alignak.http.generic_interface import GenericInterface
-from alignak.util import nighty_five_percent
+from alignak.util import average_percentile
 
 
 class SchedulerInterface(GenericInterface):
@@ -156,13 +156,20 @@ class SchedulerInterface(GenericInterface):
 
         # Spare schedulers do not have such properties
         if hasattr(sched, 'services'):
-            # Get a overview of the latencies with just
-            # a 95 percentile view, but lso min/max values
+            # Get a overview of the latencies with:
+            #  * average
+            #  * maximum (95 percentile)
+            #  * minimum (5 percentile)
             latencies = [s.latency for s in sched.services]
-            lat_avg, lat_min, lat_max = nighty_five_percent(latencies)
-            res['latency'] = (0.0, 0.0, 0.0)
+            latencies.extend([s.latency for s in sched.hosts])
+            lat_avg, lat_min, lat_max = average_percentile(latencies)
+            res['latency_average'] = 0.0
+            res['latency_minimun'] = 0.0
+            res['latency_maximum'] = 0.0
             if lat_avg:
-                res['latency'] = (lat_avg, lat_min, lat_max)
+                res['latency_average'] = lat_avg
+                res['latency_minimun'] = lat_min
+                res['latency_maximum'] = lat_max
         return res
 
     @cherrypy.expose

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -84,7 +84,7 @@ from alignak.contactdowntime import ContactDowntime
 from alignak.comment import Comment
 from alignak.acknowledge import Acknowledge
 from alignak.log import logger
-from alignak.util import nighty_five_percent
+from alignak.util import average_percentile
 from alignak.load import Load
 from alignak.http.client import HTTPClient, HTTPEXCEPTIONS
 from alignak.stats import statsmgr
@@ -1853,7 +1853,7 @@ class Scheduler(object):
         # Get a overview of the latencies with just
         # a 95 percentile view, but lso min/max values
         latencies = [s.latency for s in self.services]
-        lat_avg, lat_min, lat_max = nighty_five_percent(latencies)
+        lat_avg, lat_min, lat_max = average_percentile(latencies)
         res['latency'] = (0.0, 0.0, 0.0)
         if lat_avg:
             res['latency'] = {'avg': lat_avg, 'min': lat_min, 'max': lat_max}
@@ -2032,7 +2032,7 @@ class Scheduler(object):
             # Get a overview of the latencies with just
             # a 95 percentile view, but lso min/max values
             latencies = [s.latency for s in self.services]
-            lat_avg, lat_min, lat_max = nighty_five_percent(latencies)
+            lat_avg, lat_min, lat_max = average_percentile(latencies)
             if lat_avg is not None:
                 logger.debug("Latency (avg/min/max): %.2f/%.2f/%.2f", lat_avg, lat_min, lat_max)
 

--- a/alignak/util.py
+++ b/alignak/util.py
@@ -55,10 +55,10 @@ macros solving, sorting, parsing, file handling, filters.
 """
 import time
 import re
-import copy
 import sys
 import os
 import json
+import numpy as np
 
 from alignak.macroresolver import MacroResolver
 from alignak.log import logger
@@ -786,42 +786,25 @@ def sort_by_ids(x00, y00):
     return 0
 
 
-def nighty_five_percent(table):
+def average_percentile(values):
     """
-    From a tab, get the avg, min, max
-    for the tab values, but not the lower ones
-    and higher ones that are too distinct
-    than major ones
+    Get the average, min percentile (5%) and
+    max percentile (95%) of a list of values.
 
-    :param table: list of value to compute
-    :type table:
+    :param values: list of value to compute
+    :type values: list
     :return: tuple containing average, min and max value
     :rtype: tuple
     """
-    t02 = copy.copy(table)
-    t02.sort()
+    length = len(values)
 
-    length = len(table)
-
-    # If void tab, wtf??
     if length == 0:
-        return (None, None, None)
+        return None, None, None
 
-    t_reduce = t02
-    # only take a part if we got more
-    # than 100 elements, or it's a non sense
-    if length > 100:
-        offset = int(length * 0.05)
-        t_reduce = t_reduce[offset:-offset]
-
-    reduce_len = len(t_reduce)
-    reduce_sum = sum(t_reduce)
-
-    reduce_avg = float(reduce_sum) / reduce_len
-    reduce_max = max(t_reduce)
-    reduce_min = min(t_reduce)
-
-    return (reduce_avg, reduce_min, reduce_max)
+    value_avg = round(float(sum(values)) / length, 1)
+    value_max = round(np.percentile(values, 95), 1)
+    value_min = round(np.percentile(values, 5), 1)
+    return value_avg, value_min, value_max
 
 
 # #################### Cleaning ##############

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pbr
 termcolor==1.1.0
 setproctitle
 ujson
+numpy

--- a/test/test_utils_functions.py
+++ b/test/test_utils_functions.py
@@ -19,8 +19,9 @@
 # along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import numpy as np
 from collections import namedtuple
-from alignak.util import alive_then_spare_then_deads
+from alignak.util import alive_then_spare_then_deads, average_percentile
 from alignak_test import unittest
 
 
@@ -51,6 +52,12 @@ class TestUnknownEventHandler(unittest.TestCase):
         self.assertListEqual(sat_list[:5], expected_sat_list,
                             "Function alive_then_spare_then_deads does not sort as exepcted!")
 
+    def test_average_percentile(self):
+        my_values = [10, 8, 9, 7, 3, 11, 7, 13, 9, 10]
+        lat_avg, lat_min, lat_max = average_percentile(my_values)
+        self.assertEqual(8.7, lat_avg, 'Average')
+        self.assertEqual(4.8, lat_min, 'Minimum')
+        self.assertEqual(12.1, lat_max, 'Maximum')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Rewrite function correctly with percentile usage (95 for max and 5 for min).
Be careful, I introduce numpy dependance. I think we will use it because I want to enhance the get_raw_stats and general stats of alignak in the future