### PR TITLE
Enh/Fix: prevent memleak in any module worker who use logging

### DIFF
--- a/alignak/worker.py
+++ b/alignak/worker.py
@@ -59,11 +59,11 @@ import traceback
 import cStringIO
 
 
-from alignak.log import logger
+from alignak.log import logger, BrokHandler
 from alignak.misc.common import setproctitle
 
 
-class Worker:
+class Worker(object):
     """This class is used for poller and reactionner to work.
     The worker is a process launch by theses process and read Message in a Queue
     (self.s) (slave)
@@ -94,7 +94,8 @@ class Worker:
         # By default, take our own code
         if target is None:
             target = self.work
-        self._process = Process(target=target, args=(slave_q, returns_queue, self._control_q))
+        self._process = Process(target=self._prework,
+                                args=(target, slave_q, returns_queue, self._control_q))
         self.returns_queue = returns_queue
         self.max_plugins_output_length = max_plugins_output_length
         self.i_am_dying = False
@@ -104,6 +105,14 @@ class Worker:
             self.http_daemon = http_daemon
         else:  # windows forker do not like pickle http/lock
             self.http_daemon = None
+
+    def _prework(self, real_work, *args):
+        """Simply drop the BrokHandler before doing the real_work"""
+        for handler in list(logger.handlers):
+            if isinstance(handler, BrokHandler):
+                logger.info("Cleaning BrokHandler %r from logger.handlers..", handler)
+                logger.removeHandler(handler)
+        real_work(*args)
 
     def is_mortal(self):
         """


### PR DESCRIPTION
The module worker doesn't forward their broks to their parent process / anywhere.
