### PR TITLE
Enh: Init script - Clean and add fallbacks for lsb functions

### DIFF
--- a/bin/init.d/alignak
+++ b/bin/init.d/alignak
@@ -83,71 +83,21 @@ fi
 curpath=$(cd $(dirname "$0") && pwd)
 #echo curpath is $curpath filename is $(basename "$0")
 
-## Default paths:
-test "$BIN" || BIN=$(cd $curpath/.. && pwd)
-test "$VAR" || VAR=$(cd $curpath/../../var && pwd)
-test "$ETC" || ETC=$(cd $curpath/../../etc && pwd)
 
-export PATH="${PATH:+$PATH:}/usr/sbin:/bin:/sbin"
 export LANG=en_US.UTF8
 export LC_ALL=en_US.UTF8
 export PYTHONIOENCODING=utf8
 export PYTHONUNBUFFERED="0"
 export TZ=:/etc/localtime
-# also unset http proxy, because pycurl is using it and this is bad, very bad :)
-unset http_proxy
-unset https_proxy
-
-# We try to find the LAST possible Python VERSION
-pythonver() {
-    versions="2.4 2.5 2.6 2.7"
-    LASTFOUND=""
-    # Is there any python here?
-    for v in $versions
-    do
-        which python$v > /dev/null 2>&1
-        if [ $? -eq 0 ]
-        then
-            LASTFOUND="python$v"
-        fi
-    done
-    if [ -z "$LASTFOUND" ]
-    then
-        # Finaly try to find a default python
-        which python > /dev/null 2>&1
-        if [ $? -ne 0 ]
-        then
-            echo "No python interpreter found!"
-            exit 2
-        else
-            echo "python found"
-            LASTFOUND=$(which python)
-        fi
-    fi
-    PYTHON=$LASTFOUND
-}
-
-# Ok, go search this Python version
-pythonver
-
-# Uncomment the line below if you got the **lib** alignak installed
-# on a non standard place (not in /usr/lib/python*)
-#export PYTHONPATH="${PATH:+$PATH:}/opt/alignak"
-# Or uncommentif you want to force the Python version
-#export PYTHON=python2.7
 
 # default
 DEBUG=false
 CMD=""
 SUBMODULES=""
 
-## This permits to overhidde the default "default alignak cfg file":
+# Try relative first (if we have /usr/local for example
 [ -z "$ALIGNAK_DEFAULT_FILE" ] && ALIGNAK_DEFAULT_FILE="${curpath}/../default/$NAME"
-## so you can now do:
-## bash -c "ALIGNAK_DEFAULT_FILE=$your_own_default_file $init_path/alignak $action $args"
-## to easily use your own config
-
-#echo "Using $ALIGNAK_DEFAULT_FILE .."
+[ ! -f "$ALIGNAK_DEFAULT_FILE" ] && ALIGNAK_DEFAULT_FILE="/etc/default/$NAME"
 
 
 
@@ -204,23 +154,25 @@ fi
 # happy for opening its pid and cmd files
 cd $VAR
 
-#echo BIN=$BIN
-#echo VAR=$VAR
-#echo ETC=$ETC
-
-#set -xv
 
 
-echo_success() {
-   log_end_msg 0 $*
+# In case not existing, define here
+log_failure_msg() {
+    echo $*
+    return 1
 }
 
-echo_failure() {
-    log_end_msg 1 $*
+log_warning_msg() {
+    echo $*
+    return 1
 }
 
-#log_end_msg
-
+log_end_msg() {
+    code=$1
+    shift
+    echo $*
+    return $code
+}
 
 # Load the VERBOSE setting and other rcS variables
 [ -f /etc/default/rcS ] && . /etc/default/rcS
@@ -230,7 +182,13 @@ echo_failure() {
 
 [ -f /lib/lsb/init-functions ] && . /lib/lsb/init-functions
 
+echo_success() {
+    log_end_msg 0 $*
+}
 
+echo_failure() {
+    log_end_msg 1 $*
+}
 
 ################################################
 
@@ -315,14 +273,14 @@ do_start() {
     if [ "$mod" != "arbiter" ]; then
         modINI=$(echo "$"${mod}CFG | tr '[:lower:]' '[:upper:]')
         modinifile=$(eval echo ${modINI})
-        output=$($PYTHON "$modfilepath" -d -c "${modinifile}" $DEBUGCMD 2>&1)
+        output=$($modfilepath -d -c "${modinifile}" $DEBUGCMD 2>&1)
         rc=$?
     else
         if ! test "$ALIGNAKSPECIFICCFG"
         then
-            output=$($PYTHON "$modfilepath" -d -c "$ALIGNAKCFG" $DEBUGCMD 2>&1)
+            output=$($modfilepath -d -c "$ALIGNAKCFG" $DEBUGCMD 2>&1)
         else
-            output=$($PYTHON "$modfilepath" -d -c "$ALIGNAKCFG" -c "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1)
+            output=$($modfilepath -d -c "$ALIGNAKCFG" -c "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1)
         fi
         rc=$?
     fi
@@ -353,7 +311,7 @@ do_stop() {
     }
     if [ ! -z "$pid" ]; then
         kill "$pid"
-        sleep 1
+        #sleep 1
         ## TODO: instead of 'sleep 1': wait up to when pid file is removed (with timeout)?
         for i in 1 2 3
         do
@@ -408,9 +366,9 @@ do_check() {
     [ "$DEBUG" = 1 ] && DEBUGCMD="--debug $VAR/${mod}-debug.log"
     if ! test "$ALIGNAKSPECIFICCFG"
     then
-       $PYTHON "$BIN/alignak-arbiter" -v -c "$ALIGNAKCFG" $DEBUGCMD 2>&1
+       $BIN/alignak-arbiter -v -c "$ALIGNAKCFG" $DEBUGCMD 2>&1
     else
-       $PYTHON "$BIN/alignak-arbiter" -v -c "$ALIGNAKCFG" -c "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1
+       $BIN/alignak-arbiter -v -c "$ALIGNAKCFG" -c "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1
     fi
     return $?
 }


### PR DESCRIPTION
Hi,

This is mainly for packaging purpose only. Basically systemd based system may have not all init function so I add a fallback. next step is provide a service file and not this file. 

I also cleaned some code, and set the default value of default file as /etc/default/alignak if the relative path does not work (sometimes /etc/init.d is symlink so /etc/init.d/../default/alignak gives /etc/rc.d/default/alignak)