### PR TITLE
Enh lot of pylint rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -309,3 +309,5 @@ int-import-graph=
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
 overgeneral-exceptions=Exception
+
+max-nested-blocks=6

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - coverage combine
   - cd .. && pep8 --max-line-length=100 --exclude='*.pyc' alignak/*
   - unset PYTHONWARNINGS
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then find -iname '*.pyc' -exec rm -rf {} \; && pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 --enable=W0107 --enable=C0204 --enable=W0109  --enable=W0223  --enable=W0311  --enable=W0404  --enable=W0623  --enable=W0633 --enable=W0640  --enable=W0105 --enable=W0141 --enable=C0325 --enable=W1201 --enable=W0231 --enable=W0611 --enable=C0326 --enable=W0122 --enable=E0102 --enable=W0401 --enable=W0622 --enable=C0103 --enable=E1101 --enable=R0801 --enable=W0612 -r no alignak/*; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then find -iname '*.pyc' -exec rm -rf {} \; && pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 --enable=W0107 --enable=C0204 --enable=W0109  --enable=W0223  --enable=W0311  --enable=W0404  --enable=W0623  --enable=W0633 --enable=W0640  --enable=W0105 --enable=W0141 --enable=C0325 --enable=W1201 --enable=W0231 --enable=W0611 --enable=C0326 --enable=W0122 --enable=E0102 --enable=W0401 --enable=W0622 --enable=C0103 --enable=E1101 --enable=R0801 --enable=W0612 --enable=C0411 --enable=R0101 --enable=W0631 --enable=E0401 --enable=W0221 --enable=R0204 --enable=C0412 --enable=W0621 --enable=E0602 --enable=C0301 --enable=C0113 --enable=W0104 --enable=R0202 --enable=E0213 --enable=C0122 -r no alignak; fi
   - export PYTHONWARNINGS=all
   - pep257 --select=D300 alignak
   - cd test && (pkill -6 -f "alignak_-" || :) && python full_tst.py && cd ..

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -343,7 +343,7 @@ class ActionBase(object):
                 return True
         return False
 
-    def execute__(self):
+    def execute__(self, force_shell=False):
         """Execute action in a subprocess
 
         :return: None
@@ -402,8 +402,6 @@ if os.name != 'nt':
         def execute__(self, force_shell=sys.version_info < (2, 7)):
             """Execute action in a subprocess
 
-            :param force_shell: if True, force execution in a shell
-            :type force_shell: bool
             :return: None or str 'toomanyopenfiles'
             TODO: Clean this
             """
@@ -486,7 +484,7 @@ else:
 
         properties = ActionBase.properties.copy()
 
-        def execute__(self):
+        def execute__(self, force_shell=False):
             """Execute action in a subprocess
 
             :return: None

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -509,7 +509,7 @@ else:
                 self.process = subprocess.Popen(
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                     env=self.local_env, shell=True)
-            except WindowsError, exp:
+            except WindowsError, exp: # pylint: disable=E0602
                 logger.info("We kill the process: %s %s", exp, self.command)
                 self.status = 'timeout'
                 self.execution_time = time.time() - self.check_time

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -475,7 +475,7 @@ if os.name != 'nt':
 
 else:
 
-    import ctypes
+    import ctypes  # pylint: disable=C0411
 
     class Action(ActionBase):
         """Action class for Windows systems

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -507,7 +507,7 @@ else:
                 self.process = subprocess.Popen(
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                     env=self.local_env, shell=True)
-            except WindowsError, exp: # pylint: disable=E0602
+            except WindowsError, exp:  # pylint: disable=E0602
                 logger.info("We kill the process: %s %s", exp, self.command)
                 self.status = 'timeout'
                 self.execution_time = time.time() - self.check_time

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -82,10 +82,8 @@ from alignak.misc.common import setproctitle
 
 
 try:
-    import pwd
-    import grp
-    from pwd import getpwnam
-    from grp import getgrnam, getgrall
+    from pwd import getpwnam, getpwuid
+    from grp import getgrnam, getgrall, getgrgid
 
     def get_cur_user():
         """Wrapper for getpwuid
@@ -93,7 +91,7 @@ try:
         :return: user name
         :rtype: str
         """
-        return pwd.getpwuid(os.getuid()).pw_name
+        return getpwuid(os.getuid()).pw_name
 
     def get_cur_group():
         """Wrapper for getgrgid
@@ -101,7 +99,7 @@ try:
         :return: group name
         :rtype: str
         """
-        return grp.getgrgid(os.getgid()).gr_name
+        return getgrgid(os.getgid()).gr_name
 
     def get_all_groups():
         """Wrapper for getgrall

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -71,16 +71,6 @@ import threading
 from Queue import Empty
 from multiprocessing.managers import SyncManager
 
-
-from alignak.http.daemon import HTTPDaemon, InvalidWorkDir
-from alignak.log import logger
-from alignak.stats import statsmgr
-from alignak.modulesmanager import ModulesManager
-from alignak.property import StringProp, BoolProp, PathProp, ConfigPathProp, IntegerProp, \
-    LogLevelProp
-from alignak.misc.common import setproctitle
-
-
 try:
     from pwd import getpwnam, getpwuid
     from grp import getgrnam, getgrall, getgrgid
@@ -134,6 +124,14 @@ except ImportError, exp:  # Like in nt system
         """
         return []
 
+from alignak.http.daemon import HTTPDaemon, InvalidWorkDir
+from alignak.log import logger
+from alignak.stats import statsmgr
+from alignak.modulesmanager import ModulesManager
+from alignak.property import StringProp, BoolProp, PathProp, ConfigPathProp, IntegerProp, \
+    LogLevelProp
+from alignak.misc.common import setproctitle
+from alignak.version import VERSION
 
 IS_PY26 = sys.version_info[:2] < (2, 7)
 
@@ -142,7 +140,6 @@ IS_PY26 = sys.version_info[:2] < (2, 7)
 REDIRECT_TO = getattr(os, "devnull", "/dev/null")
 
 UMASK = 027
-from alignak.version import VERSION
 
 
 class InvalidPidFile(Exception):

--- a/alignak/daemons/brokerdaemon.py
+++ b/alignak/daemons/brokerdaemon.py
@@ -562,7 +562,7 @@ class Broker(BaseSatellite):
                 already_got = pol_id in self.pollers
                 if already_got:
                     broks = self.pollers[pol_id]['broks']
-                    running_id = self.schedulers[sched_id]['running_id']
+                    running_id = self.pollers[pol_id]['running_id']
                 else:
                     broks = {}
                     running_id = 0
@@ -597,7 +597,7 @@ class Broker(BaseSatellite):
                 already_got = rea_id in self.reactionners
                 if already_got:
                     broks = self.reactionners[rea_id]['broks']
-                    running_id = self.schedulers[sched_id]['running_id']
+                    running_id = self.reactionners[rea_id]['running_id']
                 else:
                     broks = {}
                     running_id = 0
@@ -632,7 +632,7 @@ class Broker(BaseSatellite):
                 already_got = rec_id in self.receivers
                 if already_got:
                     broks = self.receivers[rec_id]['broks']
-                    running_id = self.schedulers[sched_id]['running_id']
+                    running_id = self.receivers[rec_id]['running_id']
                 else:
                     broks = {}
                     running_id = 0

--- a/alignak/db_mysql.py
+++ b/alignak/db_mysql.py
@@ -50,9 +50,9 @@
 """This module provide DBMysql class to access MYSQL databases
 
 """
-import MySQLdb
-from MySQLdb import IntegrityError
-from MySQLdb import ProgrammingError
+import MySQLdb  # pylint: disable=E0401
+from MySQLdb import IntegrityError  # pylint: disable=E0401
+from MySQLdb import ProgrammingError  # pylint: disable=E0401
 
 
 from alignak.db import DB

--- a/alignak/db_oracle.py
+++ b/alignak/db_oracle.py
@@ -49,13 +49,13 @@
 
 """
 # Failed to import will be catch by __init__.py
-from cx_Oracle import connect as connect_function
-from cx_Oracle import IntegrityError as IntegrityError_exp
-from cx_Oracle import ProgrammingError as ProgrammingError_exp
-from cx_Oracle import DatabaseError as DatabaseError_exp
-from cx_Oracle import InternalError as InternalError_exp
-from cx_Oracle import DataError as DataError_exp
-from cx_Oracle import OperationalError as OperationalError_exp
+from cx_Oracle import connect as connect_function  # pylint: disable=E0401
+from cx_Oracle import IntegrityError as IntegrityError_exp  # pylint: disable=E0401
+from cx_Oracle import ProgrammingError as ProgrammingError_exp  # pylint: disable=E0401
+from cx_Oracle import DatabaseError as DatabaseError_exp  # pylint: disable=E0401
+from cx_Oracle import InternalError as InternalError_exp  # pylint: disable=E0401
+from cx_Oracle import DataError as DataError_exp  # pylint: disable=E0401
+from cx_Oracle import OperationalError as OperationalError_exp  # pylint: disable=E0401
 
 from alignak.db import DB
 from alignak.log import logger

--- a/alignak/db_sqlite.py
+++ b/alignak/db_sqlite.py
@@ -47,9 +47,9 @@
 """This module provide DBSqlite class to access SQLite databases
 
 """
+import sqlite3
 from alignak.db import DB
 from alignak.log import logger
-import sqlite3
 
 
 class DBSqlite(DB):

--- a/alignak/dependencynode.py
+++ b/alignak/dependencynode.py
@@ -334,11 +334,11 @@ class DependencyNode(object):
         """
         nb_sons = len(self.sons)
         # Need a list for assignment
-        self.of_values = list(self.of_values)
+        new_values = list(self.of_values)
         for i in [0, 1, 2]:
-            if self.of_values[i] == '0':
-                self.of_values[i] = str(nb_sons)
-        self.of_values = tuple(self.of_values)
+            if new_values[i] == '0':
+                new_values[i] = str(nb_sons)
+        self.of_values = tuple(new_values)
 
     def is_valid(self):
         """Check if all leaves are correct (no error)

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -259,9 +259,8 @@ class Dispatcher:
                                                realm.get_name(), kind, satellite.get_name())
                                 continue
 
-                            if satellite.alive and (
-                                        not satellite.reachable or
-                                        satellite.do_i_manage(cfg_id, push_flavor)):
+                            if satellite.alive and (not satellite.reachable or
+                                                    satellite.do_i_manage(cfg_id, push_flavor)):
                                 continue
 
                             logger.warning('[%s] The %s %s seems to be down, '

--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -33,7 +33,7 @@ class ArbiterInterface(GenericInterface):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def have_conf(self, magic_hash):
+    def have_conf(self, magic_hash=0):
         """Does the daemon got a configuration (internal) (HTTP GET)
 
         :param magic_hash: magic hash of configuration

--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -170,17 +170,17 @@ class ArbiterInterface(GenericInterface):
 
                 for props in all_props:
                     for prop in props:
-                        if hasattr(daemon, prop):
-                            val = getattr(daemon, prop)
-                            if prop == "realm":
-                                if hasattr(val, "realm_name"):
-                                    env[prop] = val.realm_name
-                            # give a try to a json able object
-                            try:
-                                json.dumps(val)
-                                env[prop] = val
-                            except Exception, exp:
-                                logger.debug('%s', exp)
+                        if not hasattr(daemon, prop):
+                            continue
+                        val = getattr(daemon, prop)
+                        if prop == "realm" and hasattr(val, "realm_name"):
+                            env[prop] = val.realm_name
+                        # give a try to a json able object
+                        try:
+                            json.dumps(val)
+                            env[prop] = val
+                        except Exception, exp:
+                            logger.debug('%s', exp)
                 lst.append(env)
         return res
 

--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -17,9 +17,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
 """This module provide a specific HTTP interface for a Arbiter."""
-import cherrypy
 import json
 import time
+
+import cherrypy
 
 from alignak.log import logger
 from alignak.http.generic_interface import GenericInterface

--- a/alignak/http/cherrypy_extend.py
+++ b/alignak/http/cherrypy_extend.py
@@ -21,12 +21,12 @@ in order to parse specific HTTP content type
 See http://cherrypy.readthedocs.org/en/latest/pkg/cherrypy.html#module-cherrypy._cpreqbody
 for details about custom processors in Cherrypy
 """
-import cherrypy
-from cherrypy._cpcompat import ntou
 import cPickle
 import json
 import zlib
 
+import cherrypy
+from cherrypy._cpcompat import ntou
 
 def zlib_processor(entity):
     """Read application/zlib data and put content into entity.params for later use.

--- a/alignak/http/cherrypy_extend.py
+++ b/alignak/http/cherrypy_extend.py
@@ -28,6 +28,7 @@ import zlib
 import cherrypy
 from cherrypy._cpcompat import ntou
 
+
 def zlib_processor(entity):
     """Read application/zlib data and put content into entity.params for later use.
 

--- a/alignak/http/daemon.py
+++ b/alignak/http/daemon.py
@@ -34,7 +34,7 @@ from cherrypy._cpreqbody import process_urlencoded, process_multipart, process_m
 
 try:
     from OpenSSL import SSL
-    from cherrypy.wsgiserver.ssl_pyopenssl import pyOpenSSLAdapter
+    from cherrypy.wsgiserver.ssl_pyopenssl import pyOpenSSLAdapter  # pylint: disable=C0412
 except ImportError:
     SSL = None
     pyOpenSSLAdapter = None  # pylint: disable=C0103

--- a/alignak/http/generic_interface.py
+++ b/alignak/http/generic_interface.py
@@ -95,7 +95,7 @@ class GenericInterface(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def have_conf(self):
+    def have_conf(self, magic_hash=None):
         """Get the daemon cur_conf state
 
         :return: boolean indicating if the daemon has a conf

--- a/alignak/http/generic_interface.py
+++ b/alignak/http/generic_interface.py
@@ -21,13 +21,14 @@ Any Alignak satellite have at least those functions exposed over network
 See : http://cherrypy.readthedocs.org/en/latest/tutorials.html for Cherrypy basic HTPP apps.
 """
 import base64
-import cherrypy
 import cPickle
 import inspect
 import logging
 import random
 import time
 import zlib
+
+import cherrypy
 
 from alignak.log import logger
 

--- a/alignak/http/scheduler_interface.py
+++ b/alignak/http/scheduler_interface.py
@@ -18,10 +18,11 @@
 # along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
 """This module provide a specific HTTP interface for a SCheduler."""
 
-import cherrypy
 import base64
 import cPickle
 import zlib
+
+import cherrypy
 
 from alignak.log import logger
 from alignak.http.generic_interface import GenericInterface

--- a/alignak/log.py
+++ b/alignak/log.py
@@ -58,8 +58,8 @@ import logging
 import sys
 import os
 import stat
-from logging import Handler, Formatter, StreamHandler, NOTSET, FileHandler
-from logging.handlers import TimedRotatingFileHandler
+from logging import Handler, Formatter, StreamHandler, NOTSET, FileHandler  # pylint: disable=C0412
+from logging.handlers import TimedRotatingFileHandler  # pylint: disable=C0412
 
 from termcolor import cprint
 

--- a/alignak/log.py
+++ b/alignak/log.py
@@ -199,7 +199,8 @@ class Log(logging.Logger):
             # It can be one of the stat.S_IS* (FIFO? CHR?)
             handler = FileHandler(path)
         else:
-            handler = TimedRotatingFileHandler(path, 'midnight', backupCount=5)
+            handler = TimedRotatingFileHandler(path, 'midnight',  # pylint: disable=R0204
+                                               backupCount=5)
         if level is not None:
             handler.setLevel(level)
         if self.name is not None:

--- a/alignak/macroresolver.py
+++ b/alignak/macroresolver.py
@@ -285,14 +285,15 @@ class MacroResolver(Borg):
                 if macros[macro]['type'] == 'class':
                     cls = macros[macro]['class']
                     for elt in data:
-                        if elt is not None and elt.__class__ == cls:
-                            prop = cls.macros[macro]
-                            macros[macro]['val'] = self._get_value_from_element(elt, prop)
-                            # Now check if we do not have a 'output' macro. If so, we must
-                            # delete all special characters that can be dangerous
-                            if macro in self.output_macros:
-                                macros[macro]['val'] = \
-                                    self._delete_unwanted_caracters(macros[macro]['val'])
+                        if elt is None or elt.__class__ != cls:
+                            continue
+                        prop = cls.macros[macro]
+                        macros[macro]['val'] = self._get_value_from_element(elt, prop)
+                        # Now check if we do not have a 'output' macro. If so, we must
+                        # delete all special characters that can be dangerous
+                        if macro in self.output_macros:
+                            macros[macro]['val'] = \
+                                self._delete_unwanted_caracters(macros[macro]['val'])
                 if macros[macro]['type'] == 'CUSTOM':
                     cls_type = macros[macro]['class']
                     # Beware : only cut the first _HOST value, so the macro name can have it on it..
@@ -301,18 +302,19 @@ class MacroResolver(Borg):
                     # Now we get the element in data that have the type HOST
                     # and we check if it got the custom value
                     for elt in data:
-                        if elt is not None and elt.__class__.my_type.upper() == cls_type:
-                            if '_' + macro_name in elt.customs:
-                                macros[macro]['val'] = elt.customs['_' + macro_name]
-                            # Then look on the macromodulations, in reserver order, so
-                            # the last to set, will be the firt to have. (yes, don't want to play
-                            # with break and such things sorry...)
-                            mms = getattr(elt, 'macromodulations', [])
-                            for macromod in mms[::-1]:
-                                # Look if the modulation got the value,
-                                # but also if it's currently active
-                                if '_' + macro_name in macromod.customs and macromod.is_active():
-                                    macros[macro]['val'] = macromod.customs['_' + macro_name]
+                        if elt is None or elt.__class__.my_type.upper() != cls_type:
+                            continue
+                        if '_' + macro_name in elt.customs:
+                            macros[macro]['val'] = elt.customs['_' + macro_name]
+                        # Then look on the macromodulations, in reserver order, so
+                        # the last to set, will be the firt to have. (yes, don't want to play
+                        # with break and such things sorry...)
+                        mms = getattr(elt, 'macromodulations', [])
+                        for macromod in mms[::-1]:
+                            # Look if the modulation got the value,
+                            # but also if it's currently active
+                            if '_' + macro_name in macromod.customs and macromod.is_active():
+                                macros[macro]['val'] = macromod.customs['_' + macro_name]
                 if macros[macro]['type'] == 'ONDEMAND':
                     macros[macro]['val'] = self._resolve_ondemand(macro, data)
 

--- a/alignak/modulesmanager.py
+++ b/alignak/modulesmanager.py
@@ -112,7 +112,7 @@ class ModulesManager(object):
         # Simple way to test if we have the required attributes
         try:
             module.properties   # pylint:disable=W0104
-            module.get_instance # pylint:disable=W0104
+            module.get_instance  # pylint:disable=W0104
         except AttributeError:
             pass
         else:

--- a/alignak/modulesmanager.py
+++ b/alignak/modulesmanager.py
@@ -109,9 +109,10 @@ class ModulesManager(object):
         :type mod_name: str
         :return: None
         """
+        # Simple way to test if we have the required attributes
         try:
-            module.properties
-            module.get_instance
+            module.properties   # pylint:disable=W0104
+            module.get_instance # pylint:disable=W0104
         except AttributeError:
             pass
         else:

--- a/alignak/objects/arbiterlink.py
+++ b/alignak/objects/arbiterlink.py
@@ -166,7 +166,7 @@ class ArbiterLinks(SatelliteLinks):
     name_property = "arbiter_name"
     inner_class = ArbiterLink
 
-    def linkify(self, modules):
+    def linkify(self, modules, realms=None):
         """
         Link modules to Arbiter
 

--- a/alignak/objects/businessimpactmodulation.py
+++ b/alignak/objects/businessimpactmodulation.py
@@ -81,7 +81,8 @@ class Businessimpactmodulation(Item):
 
 
 class Businessimpactmodulations(Items):
-    """Businessimpactmodulations class allowed to handle easily several Businessimpactmodulation objects
+    """Businessimpactmodulations class allowed to handle easily
+       several Businessimpactmodulation objects
 
     """
     name_property = "business_impact_modulation_name"

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -975,24 +975,25 @@ class Config(Item):
                     # Now walk for it.
                     for root, _, files in os.walk(cfg_dir_name, followlinks=True):
                         for c_file in files:
-                            if re.search(r"\.cfg$", c_file):
-                                if self.read_config_silent == 0:
-                                    logger.info("Processing object config file '%s'",
-                                                os.path.join(root, c_file))
-                                try:
-                                    res.write(os.linesep + '# IMPORTEDFROM=%s' %
-                                              (os.path.join(root, c_file)) + os.linesep)
-                                    file_d = open(os.path.join(root, c_file), 'rU')
-                                    res.write(file_d.read().decode('utf8', 'replace'))
-                                    # Be sure to separate files data
-                                    res.write(os.linesep)
-                                    file_d.close()
-                                except IOError, exp:
-                                    logger.error("Cannot open config file '%s' for reading: %s",
-                                                 os.path.join(root, c_file), exp)
-                                    # The configuration is invalid
-                                    # because we have a bad file!
-                                    self.conf_is_correct = False
+                            if not re.search(r"\.cfg$", c_file):
+                                continue
+                            if self.read_config_silent == 0:
+                                logger.info("Processing object config file '%s'",
+                                            os.path.join(root, c_file))
+                            try:
+                                res.write(os.linesep + '# IMPORTEDFROM=%s' %
+                                          (os.path.join(root, c_file)) + os.linesep)
+                                file_d = open(os.path.join(root, c_file), 'rU')
+                                res.write(file_d.read().decode('utf8', 'replace'))
+                                # Be sure to separate files data
+                                res.write(os.linesep)
+                                file_d.close()
+                            except IOError, exp:
+                                logger.error("Cannot open config file '%s' for reading: %s",
+                                             os.path.join(root, c_file), exp)
+                                # The configuration is invalid
+                                # because we have a bad file!
+                                self.conf_is_correct = False
                 elif re.search("^triggers_dir", line):
                     elts = line.split('=', 1)
                     if os.path.isabs(elts[1]):

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2540,11 +2540,11 @@ class Config(Item):
             self.confs[i].instance_id = i
             random.seed(time.time())
 
-    def dump(self, f=None):
+    def dump(self, dfile=None):
         """Dump configuration to a file in a JSON format
 
-        :param f: the file to dump
-        :type f: file
+        :param dfile: the file to dump
+        :type dfile: file
         :return: None
         """
         dmp = {}
@@ -2576,14 +2576,14 @@ class Config(Item):
                 objs = sorted(objs, key=lambda o, prop=name_prop: getattr(o, prop, ''))
             dmp[category] = objs
 
-        if f is None:
+        if dfile is None:
             temp_d = tempfile.gettempdir()
             path = os.path.join(temp_d, 'alignak-config-dump-%d' % time.time())
-            f = open(path, "wb")
+            dfile = open(path, "wb")
             close = True
         else:
             close = False
-        f.write(
+        dfile.write(
             json.dumps(
                 dmp,
                 indent=4,
@@ -2592,7 +2592,7 @@ class Config(Item):
             )
         )
         if close is True:
-            f.close()
+            dfile.close()
 
 
 def lazy():

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2115,7 +2115,7 @@ class Config(Item):
                         if not r_o:
                             continue
                         elt_r = elt.get_realm().realm_name
-                        if not elt_r == e_r:
+                        if elt_r != e_r:
                             logger.error("Business_rule '%s' got hosts from another realm: %s",
                                          item.get_full_name(), elt_r)
                             self.add_error("Error: Business_rule '%s' got hosts from another "

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -1122,18 +1122,18 @@ class Config(Item):
         for o_type in objectscfg:
             objects[o_type] = []
             for items in objectscfg[o_type]:
-                tmp = {}
+                tmp_obj = {}
                 for line in items:
                     elts = self._cut_line(line)
                     if elts == []:
                         continue
                     prop = elts[0]
-                    if prop not in tmp:
-                        tmp[prop] = []
+                    if prop not in tmp_obj:
+                        tmp_obj[prop] = []
                     value = ' '.join(elts[1:])
-                    tmp[prop].append(value)
-                if tmp != {}:
-                    objects[o_type].append(tmp)
+                    tmp_obj[prop].append(value)
+                if tmp_obj != {}:
+                    objects[o_type].append(tmp_obj)
 
         return objects
 
@@ -2380,7 +2380,7 @@ class Config(Item):
 
             # Now in packs we have the number of packs [h1, h2, etc]
             # equal to the number of schedulers.
-            realm.packs = packs
+            realm.packs = packs  # pylint: disable=R0204
 
         for what in (self.contacts, self.hosts, self.services, self.commands):
             logger.info("Number of %s : %d", type(what).__name__, len(what))

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2220,7 +2220,7 @@ class Config(Item):
 
         # For host/service that are business based, we need to
         # link them too
-        for serv in [serv for serv in self.services if serv.got_business_rule]:
+        for serv in [srv for srv in self.services if srv.got_business_rule]:
             for elem in serv.business_rule.list_all_elements():
                 if hasattr(elem, 'host'):  # if it's a service
                     if elem.host != serv.host:  # do not a host with itself
@@ -2230,7 +2230,7 @@ class Config(Item):
                         links.add((elem, serv.host))
 
         # Same for hosts of course
-        for host in [host for host in self.hosts if host.got_business_rule]:
+        for host in [hst for hst in self.hosts if hst.got_business_rule]:
             for elem in host.business_rule.list_all_elements():
                 if hasattr(elem, 'host'):  # if it's a service
                     if elem.host != host:

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -399,7 +399,7 @@ class Item(object):
                         value = list(getattr(self, prop))
                         value.extend(self.get_plus_and_delete(prop))
                         # Template should keep their '+'
-                        if self.is_tpl() and not value[0] == '+':
+                        if self.is_tpl() and value[0] != '+':
                             value.insert(0, '+')
                         setattr(self, prop, value)
                     return value
@@ -420,7 +420,7 @@ class Item(object):
             # Template should keep their '+' chain
             # We must say it's a '+' value, so our son will now that it must
             # still loop
-            if self.is_tpl() and value != [] and not value[0] == '+':
+            if self.is_tpl() and value != [] and value[0] != '+':
                 value.insert(0, '+')
 
             setattr(self, prop, value)

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -146,7 +146,8 @@ class Item(object):
                     else:
                         val = ''
                 else:
-                    warning = "Guessing the property %s type because it is not in %s object properties" % \
+                    warning = "Guessing the property %s type because" \
+                              "it is not in %s object properties" % \
                               (key, cls.__name__)
                     self.configuration_warnings.append(warning)
                     val = ToGuessProp.pythonize(params[key])

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -826,7 +826,7 @@ class Item(object):
                                                            tname))
         self.triggers = new_triggers
 
-    def dump(self):
+    def dump(self, dfile=None):
         """
         Dump properties
 

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -294,6 +294,7 @@ class Item(object):
             if not hasattr(self, prop) and entry.has_default:
                 setattr(self, prop, entry.default)
 
+    @classmethod
     def load_global_conf(cls, conf):
         """
         Load configuration of parent object
@@ -315,9 +316,6 @@ class Item(object):
                             setattr(cls, prop, value)
                         else:
                             setattr(cls, change_name, value)
-
-    # Make this method a classmethod
-    load_global_conf = classmethod(load_global_conf)
 
     def get_templates(self):
         """

--- a/alignak/objects/module.py
+++ b/alignak/objects/module.py
@@ -108,7 +108,7 @@ class Modules(Items):
         """
         self.linkify_s_by_plug()
 
-    def linkify_s_by_plug(self):
+    def linkify_s_by_plug(self, modules=None):
         """
         Link modules
 

--- a/alignak/objects/servicedependency.py
+++ b/alignak/objects/servicedependency.py
@@ -108,7 +108,8 @@ class Servicedependency(Item):
 
 
 class Servicedependencies(Items):
-    """Servicedependencies manage a list of Servicedependency objects, used for parsing configuration
+    """Servicedependencies manage a list of Servicedependency objects,
+       used for parsing configuration
 
     """
     inner_class = Servicedependency  # use for know what is in items

--- a/alignak/property.py
+++ b/alignak/property.py
@@ -56,9 +56,8 @@ Each class implements a pythonize method that cast data into the wanted type.
 
 """
 import re
-
-from alignak.util import to_float, to_split, to_char, to_int, unique_value, list_split
 import logging
+from alignak.util import to_float, to_split, to_char, to_int, unique_value, list_split
 
 __all__ = ('UnusedProp', 'BoolProp', 'IntegerProp', 'FloatProp',
            'CharProp', 'StringProp', 'ListProp',

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -1124,7 +1124,7 @@ class Scheduler(object):
                 self.pynag_con_init(poll['instance_id'], s_type='poller')
 
         # We loop for our passive reactionners
-        for poll in [poll for poll in self.reactionners.values() if poll['passive']]:
+        for poll in [pol for pol in self.reactionners.values() if pol['passive']]:
             logger.debug("I will get actions from the reactionner %s", str(poll))
             con = poll['con']
             if con is not None:

--- a/alignak/stats.py
+++ b/alignak/stats.py
@@ -64,8 +64,8 @@ def pad(data):
     :param data: initial data
     :return: data padded to fit BLOCK_SIZE
     """
-    pad = BLOCK_SIZE - len(data) % BLOCK_SIZE
-    return data + pad * chr(pad)
+    pad_data = BLOCK_SIZE - len(data) % BLOCK_SIZE
+    return data + pad_data * chr(pad_data)
 
 
 def unpad(padded):
@@ -74,8 +74,7 @@ def unpad(padded):
     :param padded: padded data
     :return: unpadded data
     """
-    pad = ord(padded[-1])
-    return padded[:-pad]
+    return padded[:-ord(padded[-1])]
 
 
 class Stats(object):

--- a/alignak/stats.py
+++ b/alignak/stats.py
@@ -212,7 +212,7 @@ class Stats(object):
 
         data = pad(data)
 
-        aes = AES.new(key, AES.MODE_CBC, ivs[:16])
+        aes = AES.new(key, AES.MODE_CBC, ivs[:16])  # pylint: disable=E0602
 
         encrypted = aes.encrypt(data)
         return base64.urlsafe_b64encode(encrypted)

--- a/alignak/util.py
+++ b/alignak/util.py
@@ -58,8 +58,9 @@ import re
 import sys
 import os
 import json
-import numpy as np
 import argparse
+
+import numpy as np
 
 from alignak.macroresolver import MacroResolver
 from alignak.log import logger

--- a/alignak/util.py
+++ b/alignak/util.py
@@ -131,7 +131,7 @@ def split_semicolon(line, maxsplit=None):
     splitted_line_size = len(splitted_line)
 
     # if maxsplit is not specified, we set it to the number of part
-    if maxsplit is None or 0 > maxsplit:
+    if maxsplit is None or maxsplit < 0:
         maxsplit = splitted_line_size
 
     # Join parts  to the next one, if ends with a '\'

--- a/alignak/worker.py
+++ b/alignak/worker.py
@@ -180,15 +180,15 @@ class Worker(object):
         """
         return self._mortal and self._idletime > self._timeout
 
-    def add_idletime(self, time):
+    def add_idletime(self, amount):
         """
         Increment idletime
 
-        :param time: time to increment in seconds
-        :type time: int
+        :param amount: time to increment in seconds
+        :type amount: int
         :return: None
         """
-        self._idletime += time
+        self._idletime += amount
 
     def reset_idle(self):
         """


### PR DESCRIPTION
Hi,

```
:wrong-import-order (C0411): *%s comes before %s*
  Used when PEP8 import order is not respected (standard imports first, then
  third-party libraries, then local imports) This message belongs to the imports
  checker.

:too-many-nested-blocks (R0101): *Too many nested blocks (%s/%s)*
  Used when a function or a method has too many nested blocks. This makes the
  code less understandable and maintainable. This message belongs to the elif
  checker.

:undefined-loop-variable (W0631): *Using possibly undefined loop variable %r*
  Used when an loop variable (i.e. defined by a for loop or a list comprehension
  or a generator expression) is used outside the loop. This message belongs to
  the variables checker.

:import-error (E0401): *Unable to import %s*
  Used when pylint has been unable to import a module. This message belongs to
  the imports checker.

:arguments-differ (W0221): *Arguments number differs from %s %r method*
  Used when a method has a different number of arguments than in the implemented
  interface or in an overridden method. This message belongs to the classes
  checker.

:redefined-variable-type (R0204): *Redefinition of %s type from %s to %s*
  Used when the type of a variable changes inside a method or a function. This
  message belongs to the multiple_types checker.

:ungrouped-imports (C0412): *Imports from package %s are not grouped*
  Used when imports are not grouped by packages This message belongs to the
  imports checker.

:redefined-outer-name (W0621): *Redefining name %r from outer scope (line %s)*
  Used when a variable's name hide a name defined in the outer scope. This
  message belongs to the variables checker.

:undefined-variable (E0602): *Undefined variable %r*
  Used when an undefined variable is accessed. This message belongs to the
  variables checker.

:line-too-long (C0301): *Line too long (%s/%s)*
  Used when a line is longer than a given number of characters. This message
  belongs to the format checker.

:unneeded-not (C0113): *Consider changing "%s" to "%s"*
  Used when a boolean expression contains an unneeded negation. This message
  belongs to the basic checker.

:pointless-statement (W0104): *Statement seems to have no effect*
  Used when a statement doesn't have (or at least seems to) any effect. This
  message belongs to the basic checker.

:no-classmethod-decorator (R0202): *Consider using a decorator instead of calling classmethod*
  Used when a class method is defined without using the decorator syntax. This
  message belongs to the classes checker.

:no-self-argument (E0213): *Method should have "self" as first argument*
  Used when a method has an attribute different the "self" as first argument.
  This is considered as an error since this is a so common convention that you
  shouldn't break it! This message belongs to the classes checker.

:misplaced-comparison-constant (C0122): *Comparison should be %s*
  Used when the constant is placed on the left sideof a comparison. It is
  usually clearer in intent to place it in the right hand side of the
  comparison. This message belongs to the basic checker.

```

Related to #262 #87 and naparuba/shinken#1393