### PR TITLE
Pylint rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -40,8 +40,9 @@ load-plugins=
 # W0511 : *FIXME or XXX is detected.* Reenable when done. To link with roadmap
 # W0212 : *Access to a protected member %s of a client class*. Reenable when _id replace by uuid
 # W0201 : *Attribute %r defined outside __init__*. Because we instanciate object with properties dict
-# C0330:  *Wrong %s indentation%s%s.* Conflict with pep8
-disable=C1001,W0201,W0212,I0011,W0511,C0330
+# C0330 : *Wrong %s indentation%s%s.* Conflict with pep8
+# E0203 : *Access to member %r before its definition line %s*. Because we instanciate object with properties dict
+disable=C1001,W0201,W0212,I0011,W0511,C0330,E0203
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -262,7 +262,7 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=10
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore

--- a/.pylintrc
+++ b/.pylintrc
@@ -290,7 +290,7 @@ max-attributes=7
 min-public-methods=2
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=30
 
 
 [IMPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -269,7 +269,7 @@ max-args=5
 ignored-argument-names=_.*
 
 # Maximum number of locals for function / method body
-max-locals=15
+max-locals=25
 
 # Maximum number of return / yield for function / method body
 max-returns=10

--- a/.pylintrc
+++ b/.pylintrc
@@ -287,7 +287,7 @@ max-parents=7
 max-attributes=7
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=1
 
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=30

--- a/.pylintrc
+++ b/.pylintrc
@@ -275,7 +275,7 @@ max-locals=25
 max-returns=10
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=16
 
 # Maximum number of statements in function / method body
 max-statements=80

--- a/.pylintrc
+++ b/.pylintrc
@@ -275,7 +275,7 @@ max-locals=25
 max-returns=10
 
 # Maximum number of branch for function / method body
-max-branches=16
+max-branches=20
 
 # Maximum number of statements in function / method body
 max-statements=80

--- a/.pylintrc
+++ b/.pylintrc
@@ -284,7 +284,7 @@ max-statements=80
 max-parents=7
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=25
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=1

--- a/.pylintrc
+++ b/.pylintrc
@@ -278,7 +278,7 @@ max-returns=10
 max-branches=12
 
 # Maximum number of statements in function / method body
-max-statements=50
+max-statements=80
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - coverage combine
   - cd .. && pep8 --max-line-length=100 --exclude='*.pyc' alignak/*
   - unset PYTHONWARNINGS
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then find -iname '*.pyc' -exec rm -rf {} \; && pylint --rcfile=.pylintrc --disable=all --enable=C0111 --enable=W0403 --enable=W0106 --enable=W1401 --enable=W0614 --enable=W0107 --enable=C0204 --enable=W0109  --enable=W0223  --enable=W0311  --enable=W0404  --enable=W0623  --enable=W0633 --enable=W0640  --enable=W0105 --enable=W0141 --enable=C0325 --enable=W1201 --enable=W0231 --enable=W0611 --enable=C0326 --enable=W0122 --enable=E0102 --enable=W0401 --enable=W0622 --enable=C0103 --enable=E1101 --enable=R0801 --enable=W0612 --enable=C0411 --enable=R0101 --enable=W0631 --enable=E0401 --enable=W0221 --enable=R0204 --enable=C0412 --enable=W0621 --enable=E0602 --enable=C0301 --enable=C0113 --enable=W0104 --enable=R0202 --enable=E0213 --enable=C0122 --enable=W0102 --enable=W0102 --enable=E0611 --enable=W0603 --enable=C0413 --enable=R0102 --enable=R0911 --enable=C0302 -r no alignak; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then find -iname '*.pyc' -exec rm -rf {} \; && pylint --rcfile=.pylintrc -r no alignak; fi
   - export PYTHONWARNINGS=all
   - pep257 --select=D300 alignak
   - cd test && (pkill -6 -f "alignak_-" || :) && python full_tst.py && cd ..

--- a/alignak/acknowledge.py
+++ b/alignak/acknowledge.py
@@ -99,6 +99,7 @@ class Acknowledge:  # pylint: disable=R0903
         self.end_time = end_time
         self.author = author
         self.comment = comment
+        self.persistent = persistent
 
     def __getstate__(self):
         """Call by pickle for dataify the acknowledge

--- a/alignak/acknowledge.py
+++ b/alignak/acknowledge.py
@@ -51,7 +51,7 @@ implements acknowledgment for notification. Basically used for parsing.
 """
 
 
-class Acknowledge:
+class Acknowledge:  # pylint: disable=R0903
     """
     Allows you to acknowledge the current problem for the specified service.
     By acknowledging the current problem, future notifications (for the same

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -97,7 +97,7 @@ def no_block_read(output):
     fcntl.fcntl(o_fd, fcntl.F_SETFL, o_fl | os.O_NONBLOCK)
     try:
         return output.read()
-    except Exception:
+    except Exception:  # pylint: disable=W0703
         return ''
 
 
@@ -421,7 +421,7 @@ if os.name != 'nt':
             else:
                 try:
                     cmd = shlex.split(self.command.encode('utf8', 'ignore'))
-                except Exception, exp:
+                except Exception, exp:  # pylint: disable=W0703
                     self.output = 'Not a valid shell command: ' + exp.__str__()
                     self.exit_status = 3
                     self.status = 'done'
@@ -469,7 +469,7 @@ if os.name != 'nt':
             for file_d in [self.process.stdout, self.process.stderr]:
                 try:
                     file_d.close()
-                except Exception:
+                except Exception:  # pylint: disable=W0703
                     pass
 
 
@@ -496,7 +496,7 @@ else:
             else:
                 try:
                     cmd = shlex.split(self.command.encode('utf8', 'ignore'))
-                except Exception, exp:
+                except Exception, exp:  # pylint: disable=W0703
                     self.output = 'Not a valid shell command: ' + exp.__str__()
                     self.exit_status = 3
                     self.status = 'done'

--- a/alignak/basemodule.py
+++ b/alignak/basemodule.py
@@ -191,7 +191,7 @@ class BaseModule(object):
             logger.error('[%s] %s', self.name, traceback.format_exc())
             raise exp
 
-    def start(self, http_daemon=None):
+    def start(self, http_daemon=None):  # pylint: disable=W0613
         """Actually restart the process if the module is external
         Try first to stop the process and create a new Process instance
         with target start_module.
@@ -283,7 +283,7 @@ class BaseModule(object):
             DeprecationWarning, stacklevel=2)
         return hasattr(self, prop)
 
-    def want_brok(self, b):
+    def want_brok(self, b):  # pylint: disable=W0613,R0201
         """Generic function to check if the module need a specific brok
         In this case it is always True
 
@@ -309,7 +309,7 @@ class BaseModule(object):
             brok.prepare()
             return manage(brok)
 
-    def manage_signal(self, sig, frame):
+    def manage_signal(self, sig, frame):  # pylint: disable=W0613
         """Generic function to handle signals
         Set interrupted attribute to True and return
 

--- a/alignak/borg.py
+++ b/alignak/borg.py
@@ -47,7 +47,7 @@
 """
 
 
-class Borg(object):
+class Borg(object):  # pylint: disable=R0903
     """Borg class define a simple __shared_state class attribute.
     __dict__ points to this value when calling __init__
 

--- a/alignak/check.py
+++ b/alignak/check.py
@@ -84,8 +84,8 @@ class Check(Action):  #pylint: disable=R0902
         'from_trigger':     BoolProp(default=False),
     })
 
-    def __init__(self, status, command, ref, t_to_go, dep_check=None, _id=None,
-                 timeout=10, poller_tag='None', reactionner_tag='None',
+    def __init__(self, status, command, ref, t_to_go, dep_check=None,  # pylint: disable=R0913
+                 _id=None, timeout=10, poller_tag='None', reactionner_tag='None',
                  env=None, module_type='fork', from_trigger=False, dependency_check=False):
 
         self.is_a = 'check'

--- a/alignak/check.py
+++ b/alignak/check.py
@@ -55,7 +55,7 @@ from alignak.property import BoolProp, IntegerProp, ListProp
 from alignak.property import StringProp
 
 
-class Check(Action):  #pylint: disable=R0902
+class Check(Action):  # pylint: disable=R0902
     """Check class implements monitoring concepts of checks :(status, state, output)
     Check instance are used to store monitoring plugins data (exit status, output)
     and used by schedule to raise alert, reschedule check etc.

--- a/alignak/check.py
+++ b/alignak/check.py
@@ -55,7 +55,7 @@ from alignak.property import BoolProp, IntegerProp, ListProp
 from alignak.property import StringProp
 
 
-class Check(Action):
+class Check(Action):  #pylint: disable=R0902
     """Check class implements monitoring concepts of checks :(status, state, output)
     Check instance are used to store monitoring plugins data (exit status, output)
     and used by schedule to raise alert, reschedule check etc.

--- a/alignak/commandcall.py
+++ b/alignak/commandcall.py
@@ -90,7 +90,7 @@ class CommandCall(DummyCommandCall):
     }
 
     def __init__(self, commands, call, poller_tag='None',
-                 reactionner_tag='None', enable_environment_macros=0):
+                 reactionner_tag='None', enable_environment_macros=False):
         self._id = self.__class__._id
         self.__class__._id += 1
         self.call = call
@@ -100,6 +100,7 @@ class CommandCall(DummyCommandCall):
         self.command = commands.find_by_name(self.command.strip())
         self.late_relink_done = False  # To do not relink again and again the same commandcall
         self.valid = self.command is not None
+        self.enable_environment_macros = enable_environment_macros
         if self.valid:
             # If the host/service do not give an override poller_tag, take
             # the one of the command

--- a/alignak/commandcall.py
+++ b/alignak/commandcall.py
@@ -53,7 +53,7 @@ from alignak.autoslots import AutoSlots
 from alignak.property import StringProp, BoolProp, IntegerProp
 
 
-class DummyCommandCall(object):
+class DummyCommandCall(object):  # pylint: disable=R0903
     """Ok, slots are fun: you cannot set the __autoslots__
      on the same class you use, fun isn't it? So we define*
      a dummy useless class to get such :)

--- a/alignak/complexexpression.py
+++ b/alignak/complexexpression.py
@@ -152,7 +152,7 @@ class ComplexExpressionFactory(object):
         self.grps = grps
         self.all_elements = all_elements
 
-    def eval_cor_pattern(self, pattern):
+    def eval_cor_pattern(self, pattern):  # pylint:disable=R0912
         """Parse and build recursively a tree of ComplexExpressionNode from pattern
 
         :param pattern: pattern to parse

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -152,7 +152,7 @@ DEFAULT_WORK_DIR = '/var/run/alignak/'
 DEFAULT_LIB_DIR = '/var/lib/alignak/'
 
 
-class Daemon(object):  #pylint: disable=R0902
+class Daemon(object):  # pylint: disable=R0902
     """Class providing daemon level call for Alignak
         TODO: Consider clean this code and use standard libs
     """

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -152,7 +152,7 @@ DEFAULT_WORK_DIR = '/var/run/alignak/'
 DEFAULT_LIB_DIR = '/var/lib/alignak/'
 
 
-class Daemon(object):
+class Daemon(object):  #pylint: disable=R0902
     """Class providing daemon level call for Alignak
         TODO: Consider clean this code and use standard libs
     """

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -263,7 +263,7 @@ class Daemon(object):  # pylint: disable=R0902
                 logger.warning("http_thread failed to terminate. Calling _Thread__stop")
                 try:
                     self.http_thread._Thread__stop()
-                except Exception:
+                except Exception:  # pylint: disable=W0703
                     pass
             self.http_thread = None
 
@@ -357,7 +357,8 @@ class Daemon(object):  # pylint: disable=R0902
         """
         pass
 
-    def dump_memory(self):
+    @staticmethod
+    def dump_memory():
         """Try to dump memory
         Does not really work :/
 
@@ -411,7 +412,7 @@ class Daemon(object):  # pylint: disable=R0902
         logger.debug("Unlinking %s", self.pidfile)
         try:
             os.unlink(self.pidfile)
-        except Exception, exp:
+        except OSError, exp:
             logger.error("Got an error unlinking our pidfile: %s", exp)
 
     def register_local_log(self):
@@ -429,7 +430,8 @@ class Daemon(object):  # pylint: disable=R0902
                 sys.exit(2)
             logger.info("Using the local log file '%s'", self.local_log)
 
-    def check_shm(self):
+    @staticmethod
+    def check_shm():
         """ Check /dev/shm right permissions
 
         :return: None
@@ -481,13 +483,14 @@ class Daemon(object):  # pylint: disable=R0902
         self.__open_pidfile()
         try:
             pid = int(self.fpid.readline().strip(' \r\n'))
-        except Exception as err:
+        except (IOError, ValueError) as err:
             logger.info("Stale pidfile exists at %s (%s). Reusing it.", err, self.pidfile)
             return
 
         try:
             os.kill(pid, 0)
-        except Exception as err:  # consider any exception as a stale pidfile.
+        except Exception as err:  # pylint: disable=W0703
+            # consider any exception as a stale pidfile.
             # this includes :
             #  * PermissionError when a process with same pid exists but is executed by another user
             #  * ProcessLookupError: [Errno 3] No such process
@@ -528,7 +531,8 @@ class Daemon(object):  # pylint: disable=R0902
         self.fpid.close()
         del self.fpid  # no longer needed
 
-    def close_fds(self, skip_close_fds):
+    @staticmethod
+    def close_fds(skip_close_fds):
         """Close all the process file descriptors.
         Skip the descriptors present in the skip_close_fds list
 
@@ -585,7 +589,7 @@ class Daemon(object):  # pylint: disable=R0902
         if pid != 0:
             # In the father: we check if our child exit correctly
             # it has to write the pid of our future little child..
-            def do_exit(sig, frame):
+            def do_exit(sig, frame):  # pylint: disable=W0613
                 """Exit handler if wait too long during fork
 
                 :param sig: signal
@@ -723,7 +727,8 @@ class Daemon(object):  # pylint: disable=R0902
                                       use_ssl, ca_cert, ssl_key,
                                       ssl_cert, self.daemon_thread_pool_size)
 
-    def get_socks_activity(self, socks, timeout):
+    @staticmethod
+    def get_socks_activity(socks, timeout):
         """ Global loop part : wait for socket to be ready
 
         :param socks: a socket file descriptor list
@@ -891,7 +896,7 @@ class Daemon(object):  # pylint: disable=R0902
                 setattr(self, prop, path)
                 # print "Setting %s for %s" % (path, prop)
 
-    def manage_signal(self, sig, frame):
+    def manage_signal(self, sig, frame):  # pylint: disable=W0613
         """Manage signals caught by the daemon
         signal.SIGUSR1 : dump_memory
         signal.SIGUSR2 : dump_object (nothing)
@@ -939,7 +944,8 @@ class Daemon(object):  # pylint: disable=R0902
         """
         setproctitle("alignak-%s" % self.name)
 
-    def get_header(self):
+    @staticmethod
+    def get_header():
         """Get the log file header
 
         :return: A string list containing project name, version, licence etc.
@@ -969,7 +975,7 @@ class Daemon(object):  # pylint: disable=R0902
         # finish
         try:
             self.http_daemon.run()
-        except Exception, exp:
+        except Exception, exp:  # pylint: disable=W0703
             logger.exception('The HTTP daemon failed with the error %s, exiting', str(exp))
             raise exp
 
@@ -1036,7 +1042,7 @@ class Daemon(object):  # pylint: disable=R0902
 
         return difference
 
-    def compensate_system_time_change(self, difference):
+    def compensate_system_time_change(self, difference):  # pylint: disable=R0201
         """Default action for system time change. Actually a log is done
 
         :return: None
@@ -1078,13 +1084,13 @@ class Daemon(object):  # pylint: disable=R0902
                 fun = getattr(inst, full_hook_name)
                 try:
                     fun(self)
-                except Exception as exp:
+                except Exception as exp:  # pylint: disable=W0703
                     logger.warning('The instance %s raised an exception %s. I disabled it,'
                                    'and set it to restart later', inst.get_name(), str(exp))
                     self.modules_manager.set_to_restart(inst)
         statsmgr.incr('core.hook.%s' % hook_name, time.time() - _t0)
 
-    def get_retention_data(self):
+    def get_retention_data(self):  # pylint: disable=R0201
         """Basic function to get retention data,
         Maybe be overridden by subclasses to implement real get
 

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -59,6 +59,7 @@
 """
 This module provides abstraction for creating daemon in Alignak
 """
+# pylint: disable=R0904
 from __future__ import print_function
 import os
 import errno

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -80,7 +80,7 @@ from alignak.property import BoolProp
 from alignak.http.arbiter_interface import ArbiterInterface
 
 
-class Arbiter(Daemon):  #pylint: disable=R0902
+class Arbiter(Daemon):  # pylint: disable=R0902
     """Arbiter class. Referenced as "app" in most Interface
 
     """

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -208,7 +208,7 @@ class Arbiter(Daemon):
         # the attribute name to get these differs for schedulers and arbiters
         return daemon_type + 's'
 
-    def load_config_file(self):
+    def load_config_file(self):  # pylint: disable=R0915
         """Load main configuration file (alignak.cfg)::
 
         * Read all files given in the -c parameters

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -197,7 +197,8 @@ class Arbiter(Daemon):  # pylint: disable=R0902
         self.external_command = ecm
         self.fifo = ecm.open()
 
-    def get_daemon_links(self, daemon_type):
+    @staticmethod
+    def get_daemon_links(daemon_type):
         """Get the name of arbiter link (here arbiters)
 
         :param daemon_type: daemon type
@@ -451,7 +452,7 @@ class Arbiter(Daemon):  # pylint: disable=R0902
             _t0 = time.time()
             try:
                 objs = inst.get_objects()
-            except Exception, exp:
+            except Exception, exp:  # pylint: disable=W0703
                 logger.error("Instance %s raised an exception %s. Log and continue to run",
                              inst.get_name(), str(exp))
                 output = cStringIO.StringIO()

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -80,7 +80,7 @@ from alignak.property import BoolProp
 from alignak.http.arbiter_interface import ArbiterInterface
 
 
-class Arbiter(Daemon):
+class Arbiter(Daemon):  #pylint: disable=R0902
     """Arbiter class. Referenced as "app" in most Interface
 
     """

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -86,7 +86,7 @@ class Arbiter(Daemon):  #pylint: disable=R0902
     """
 
     def __init__(self, config_files, is_daemon, do_replace, verify_only, debug,
-                 debug_file, profile=None, analyse=None, migrate=None, arb_name=''):
+                 debug_file, analyse=None, migrate=None, arb_name=''):
 
         super(Arbiter, self).__init__('arbiter', config_files[0], is_daemon, do_replace,
                                       debug, debug_file)

--- a/alignak/daemons/brokerdaemon.py
+++ b/alignak/daemons/brokerdaemon.py
@@ -90,7 +90,7 @@ class Broker(BaseSatellite):
         'local_log': PathProp(default='brokerd.log'),
     })
 
-    def __init__(self, config_file, is_daemon, do_replace, debug, debug_file, profile=''):
+    def __init__(self, config_file, is_daemon, do_replace, debug, debug_file):
 
         super(Broker, self).__init__('broker', config_file, is_daemon, do_replace, debug,
                                      debug_file)
@@ -194,7 +194,8 @@ class Broker(BaseSatellite):
             return s_type[d_type]
         return None
 
-    def is_connection_try_too_close(self, elt):
+    @staticmethod
+    def is_connection_try_too_close(elt):
         """Check if last_connection has been made very recently
 
         :param elt: list with last_connection property
@@ -322,7 +323,7 @@ class Broker(BaseSatellite):
         for mod in self.modules_manager.get_internal_instances():
             try:
                 mod.manage_brok(brok)
-            except Exception, exp:
+            except Exception, exp:  # pylint: disable=W0703
                 logger.debug(str(exp.__dict__))
                 logger.warning("The mod %s raise an exception: %s, I'm tagging it to restart later",
                                mod.get_name(), str(exp))
@@ -413,7 +414,7 @@ class Broker(BaseSatellite):
             # scheduler must not have checks
             #  What the F**k? We do not know what happened,
             # so.. bye bye :)
-            except Exception, err:
+            except Exception, err:  # pylint: disable=W0703
                 logger.error(str(err))
                 logger.error(traceback.format_exc())
                 sys.exit(1)
@@ -446,7 +447,7 @@ class Broker(BaseSatellite):
             child.join(1)
         super(Broker, self).do_stop()
 
-    def setup_new_conf(self):  # pylint: disable=R0915
+    def setup_new_conf(self):  # pylint: disable=R0915,R0912
         """Parse new configuration and initialize all required
 
         :return: None
@@ -734,7 +735,7 @@ class Broker(BaseSatellite):
         for inst in insts:
             try:
                 logger.debug("External Queue len (%s): %s", inst.get_name(), inst.to_q.qsize())
-            except Exception, exp:
+            except Exception, exp:  # pylint: disable=W0703
                 logger.debug("External Queue len (%s): Exception! %s", inst.get_name(), exp)
 
         # Begin to clean modules
@@ -792,7 +793,7 @@ class Broker(BaseSatellite):
         for mod in ext_modules:
             try:
                 mod.to_q.put(to_send)
-            except Exception, exp:
+            except Exception, exp:  # pylint: disable=W0703
                 # first we must find the modules
                 logger.debug(str(exp.__dict__))
                 logger.warning("The mod %s queue raise an exception: %s, "

--- a/alignak/daemons/brokerdaemon.py
+++ b/alignak/daemons/brokerdaemon.py
@@ -446,7 +446,7 @@ class Broker(BaseSatellite):
             child.join(1)
         super(Broker, self).do_stop()
 
-    def setup_new_conf(self):
+    def setup_new_conf(self):  # pylint: disable=R0915
         """Parse new configuration and initialize all required
 
         :return: None

--- a/alignak/daemons/reactionnerdaemon.py
+++ b/alignak/daemons/reactionnerdaemon.py
@@ -78,6 +78,6 @@ class Reactionner(Satellite):
         'local_log': PathProp(default='reactionnerd.log'),
     })
 
-    def __init__(self, config_file, is_daemon, do_replace, debug, debug_file, profile=''):
+    def __init__(self, config_file, is_daemon, do_replace, debug, debug_file):
         super(Reactionner, self).__init__('reactionner', config_file, is_daemon, do_replace, debug,
                                           debug_file)

--- a/alignak/daemons/receiverdaemon.py
+++ b/alignak/daemons/receiverdaemon.py
@@ -168,7 +168,7 @@ class Receiver(Satellite):
         for mod in self.modules_manager.get_internal_instances():
             try:
                 mod.manage_brok(brok)
-            except Exception, exp:
+            except Exception, exp:  # pylint: disable=W0703
                 logger.warning("The mod %s raise an exception: %s, I kill it",
                                mod.get_name(), str(exp))
                 logger.warning("Exception type: %s", type(exp))

--- a/alignak/daemons/schedulerdaemon.py
+++ b/alignak/daemons/schedulerdaemon.py
@@ -226,22 +226,14 @@ class Alignak(BaseSatellite):
             modules = new_c['modules']
             satellites = new_c['satellites']
             instance_name = new_c['instance_name']
-            push_flavor = new_c['push_flavor']
-            skip_initial_broks = new_c['skip_initial_broks']
-            accept_passive_unknown_chk_res = new_c['accept_passive_unknown_check_results']
-            api_key = new_c['api_key']
-            secret = new_c['secret']
-            http_proxy = new_c['http_proxy']
-            statsd_host = new_c['statsd_host']
-            statsd_port = new_c['statsd_port']
-            statsd_prefix = new_c['statsd_prefix']
-            statsd_enabled = new_c['statsd_enabled']
 
             # horay, we got a name, we can set it in our stats objects
             statsmgr.register(self.sched, instance_name, 'scheduler',
-                              api_key=api_key, secret=secret, http_proxy=http_proxy,
-                              statsd_host=statsd_host, statsd_port=statsd_port,
-                              statsd_prefix=statsd_prefix, statsd_enabled=statsd_enabled)
+                              api_key=new_c['api_key'], secret=new_c['secret'],
+                              http_proxy=new_c['http_proxy'],
+                              statsd_host=new_c['statsd_host'], statsd_port=new_c['statsd_port'],
+                              statsd_prefix=new_c['statsd_prefix'],
+                              statsd_enabled=new_c['statsd_enabled'])
 
             t00 = time.time()
             conf = cPickle.loads(conf_raw)
@@ -250,10 +242,11 @@ class Alignak(BaseSatellite):
 
             # Tag the conf with our data
             self.conf = conf
-            self.conf.push_flavor = push_flavor
+            self.conf.push_flavor = new_c['push_flavor']
             self.conf.instance_name = instance_name
-            self.conf.skip_initial_broks = skip_initial_broks
-            self.conf.accept_passive_unknown_check_results = accept_passive_unknown_chk_res
+            self.conf.skip_initial_broks = new_c['skip_initial_broks']
+            self.conf.accept_passive_unknown_check_results = \
+                new_c['accept_passive_unknown_check_results']
 
             self.cur_conf = conf
             self.override_conf = override_conf

--- a/alignak/daemons/schedulerdaemon.py
+++ b/alignak/daemons/schedulerdaemon.py
@@ -83,7 +83,7 @@ class Alignak(BaseSatellite):
         'local_log': PathProp(default='schedulerd.log'),
     })
 
-    def __init__(self, config_file, is_daemon, do_replace, debug, debug_file, profile=''):
+    def __init__(self, config_file, is_daemon, do_replace, debug, debug_file):
 
         BaseSatellite.__init__(self, 'scheduler', config_file, is_daemon, do_replace, debug,
                                debug_file)

--- a/alignak/daterange.py
+++ b/alignak/daterange.py
@@ -92,7 +92,7 @@ def find_day_by_weekday_offset(year, month, weekday, offset):
             if nb_found == offset:
                 return cal[i][weekday]
         return None
-    except Exception:
+    except KeyError:
         return None
 
 
@@ -258,7 +258,7 @@ class AbstractDaterange(object):
         """
         return Daterange.rev_weekdays[weekday_id]
 
-    def get_start_and_end_time(self, ref=None):
+    def get_start_and_end_time(self, ref=None):  # pylint: disable=W0613,R0201
         """Generic function to get start time and end time
 
         :param ref: time in seconds

--- a/alignak/daterange.py
+++ b/alignak/daterange.py
@@ -576,7 +576,7 @@ class Daterange(AbstractDaterange):
     rev_weekdays = dict((v, k) for k, v in weekdays.items())
     rev_months = dict((v, k) for k, v in months.items())
 
-    def __init__(self, syear, smon, smday, swday, swday_offset,
+    def __init__(self, syear, smon, smday, swday, swday_offset,  # pylint: disable=R0913
                  eyear, emon, emday, ewday, ewday_offset, skip_interval, other):
         """
 

--- a/alignak/db.py
+++ b/alignak/db.py
@@ -55,7 +55,8 @@ class DB(object):
     def __init__(self, table_prefix=''):
         self.table_prefix = table_prefix
 
-    def stringify(self, val):
+    @staticmethod
+    def stringify(val):
         """Get a unicode from a value
 
         :param val: value to 'unicode'

--- a/alignak/db_oracle.py
+++ b/alignak/db_oracle.py
@@ -111,7 +111,7 @@ class DBOracle(DB):
         except OperationalError_exp, exp:
             logger.warning("[DBOracle] Warning: a query raise an operational error: %s, %s",
                            query, exp)
-        except Exception, exp:
+        except Exception, exp:  # pylint: disable=W0703
             logger.warning("[DBOracle] Warning: a query raise an unknown error: %s, %s",
                            query, exp)
             logger.warning(exp.__dict__)

--- a/alignak/dependencynode.py
+++ b/alignak/dependencynode.py
@@ -85,7 +85,8 @@ class DependencyNode(object):
                                                             ','.join([str(s) for s in self.sons]),
                                                             self.not_value)
 
-    def get_reverse_state(self, state):
+    @staticmethod
+    def get_reverse_state(state):
         """Do a symmetry around 1 of the state ::
 
         * 0 -> 2
@@ -399,7 +400,8 @@ class DependencyNodeFactory(object):
         else:
             return self.eval_complex_cor_pattern(pattern, hosts, services, running)
 
-    def eval_xof_pattern(self, node, pattern):
+    @staticmethod
+    def eval_xof_pattern(node, pattern):
         """Parse a X of pattern
         * Set is_of_mul attribute
         * Set of_values attribute

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -166,7 +166,7 @@ class Dispatcher:
                 arb.update_infos()
                 # print "Arb", arb.get_name(), "alive?", arb.alive, arb.__dict__
 
-    def check_dispatch(self):
+    def check_dispatch(self):  # pylint:disable=R0912
         """Check if all active items are still alive
 
         :return: None
@@ -340,7 +340,8 @@ class Dispatcher:
                                 r_id, satellite.get_name())
                     satellite.remove_from_conf(id)
 
-    def get_scheduler_ordered_list(self, realm):
+    @staticmethod
+    def get_scheduler_ordered_list(realm):
         """Get sorted scheduler list for a specific realm
 
         :param realm: realm we want scheduler from
@@ -372,7 +373,7 @@ class Dispatcher:
 
         return scheds
 
-    def dispatch(self):  # pylint: disable=R0915,R0914
+    def dispatch(self):  # pylint: disable=R0915,R0914,R0912
         """Dispatch configuration to other daemons
         REF: doc/alignak-conf-dispatching.png (3)
 

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -372,7 +372,7 @@ class Dispatcher:
 
         return scheds
 
-    def dispatch(self):  # pylint: disable=R0915
+    def dispatch(self):  # pylint: disable=R0915,R0914
         """Dispatch configuration to other daemons
         REF: doc/alignak-conf-dispatching.png (3)
 
@@ -439,13 +439,12 @@ class Dispatcher:
                         conf.push_flavor = random.randint(1, 1000000)
                         # REF: doc/alignak-conf-dispatching.png (3)
                         # REF: doc/alignak-scheduler-lost.png (2)
-                        override_conf = sched.get_override_configuration()
-                        satellites_for_sched = realm.get_satellites_links_for_scheduler()
-                        s_conf = realm.serialized_confs[conf._id]
                         # Prepare the conf before sending it
                         conf_package = {
-                            'conf': s_conf, 'override_conf': override_conf,
-                            'modules': sched.modules, 'satellites': satellites_for_sched,
+                            'conf': realm.serialized_confs[conf._id],
+                            'override_conf': sched.get_override_configuration(),
+                            'modules': sched.modules,
+                            'satellites': realm.get_satellites_links_for_scheduler(),
                             'instance_name': sched.scheduler_name, 'push_flavor': conf.push_flavor,
                             'skip_initial_broks': sched.skip_initial_broks,
                             'accept_passive_unknown_check_results':
@@ -495,8 +494,7 @@ class Dispatcher:
                         break
 
             # We pop conf to dispatch, so it must be no more conf...
-            conf_to_dispatch = [cfg for cfg in self.conf.confs.values() if not cfg.is_assigned]
-            nb_missed = len(conf_to_dispatch)
+            nb_missed = len([cfg for cfg in self.conf.confs.values() if not cfg.is_assigned])
             if nb_missed > 0:
                 logger.warning("All schedulers configurations are not dispatched, %d are missing",
                                nb_missed)

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -372,7 +372,7 @@ class Dispatcher:
 
         return scheds
 
-    def dispatch(self):
+    def dispatch(self):  # pylint: disable=R0915
         """Dispatch configuration to other daemons
         REF: doc/alignak-conf-dispatching.png (3)
 

--- a/alignak/external_command.py
+++ b/alignak/external_command.py
@@ -685,7 +685,7 @@ class ExternalCommandManager:
                 # sched.run_external_command(command)
                 sched.external_commands.append(command)
 
-    def get_command_and_args(self, command, extcmd=None):
+    def get_command_and_args(self, command, extcmd=None):  # pylint: disable=R0915
         """Parse command and get args
 
         :param command: command line to parse

--- a/alignak/external_command.py
+++ b/alignak/external_command.py
@@ -701,12 +701,10 @@ class ExternalCommandManager:
         # safe_print("Trying to resolve", command)
         command = command.rstrip()
         elts = split_semicolon(command)  # danger!!! passive checkresults with perfdata
-        part1 = elts[0]
-        elts2 = part1.split(' ')
         try:
-            timestamp = elts2[0]
+            timestamp, c_name = elts[0].split(' ')
             timestamp = timestamp[1:-1]
-            c_name = elts2[1].lower()
+            c_name = c_name.lower()
             self.current_timestamp = to_int(timestamp)
         except (ValueError, IndexError):
             logger.debug("Malformed command '%s'", command)

--- a/alignak/external_command.py
+++ b/alignak/external_command.py
@@ -58,6 +58,7 @@ Used to process command sent by users
 
 """
 # pylint: disable=C0302
+# pylint: disable=R0904
 import os
 import time
 import re

--- a/alignak/external_command.py
+++ b/alignak/external_command.py
@@ -685,7 +685,7 @@ class ExternalCommandManager:
                 # sched.run_external_command(command)
                 sched.external_commands.append(command)
 
-    def get_command_and_args(self, command, extcmd=None):  # pylint: disable=R0915
+    def get_command_and_args(self, command, extcmd=None):  # pylint: disable=R0915,R0912
         """Parse command and get args
 
         :param command: command line to parse
@@ -858,7 +858,8 @@ class ExternalCommandManager:
             logger.debug("Sorry, the arguments are not corrects (%s)", str(args))
             return None
 
-    def change_contact_modsattr(self, contact, value):
+    @staticmethod
+    def change_contact_modsattr(contact, value):
         """Change contact modified service attribute value
         Format of the line that triggers function call::
 
@@ -872,7 +873,8 @@ class ExternalCommandManager:
         """
         contact.modified_service_attributes = long(value)
 
-    def change_contact_modhattr(self, contact, value):
+    @staticmethod
+    def change_contact_modhattr(contact, value):
         """Change contact modified host attribute value
         Format of the line that triggers function call::
 
@@ -886,7 +888,8 @@ class ExternalCommandManager:
         """
         contact.modified_host_attributes = long(value)
 
-    def change_contact_modattr(self, contact, value):
+    @staticmethod
+    def change_contact_modattr(contact, value):
         """Change contact modified attribute value
         Format of the line that triggers function call::
 
@@ -956,7 +959,8 @@ class ExternalCommandManager:
         host.add_comment(comm)
         self.sched.add(comm)
 
-    def acknowledge_svc_problem(self, service, sticky, notify, persistent, author, comment):
+    @staticmethod
+    def acknowledge_svc_problem(service, sticky, notify, persistent, author, comment):
         """Acknowledge a service problem
         Format of the line that triggers function call::
 
@@ -979,7 +983,8 @@ class ExternalCommandManager:
         """
         service.acknowledge_problem(sticky, notify, persistent, author, comment)
 
-    def acknowledge_host_problem(self, host, sticky, notify, persistent, author, comment):
+    @staticmethod
+    def acknowledge_host_problem(host, sticky, notify, persistent, author, comment):
         """Acknowledge a host problem
         Format of the line that triggers function call::
 
@@ -1002,7 +1007,8 @@ class ExternalCommandManager:
         """
         host.acknowledge_problem(sticky, notify, persistent, author, comment)
 
-    def acknowledge_svc_problem_expire(self, service, sticky, notify,
+    @staticmethod
+    def acknowledge_svc_problem_expire(service, sticky, notify,
                                        persistent, end_time, author, comment):
         """Acknowledge a service problem with expire time for this acknowledgement
         Format of the line that triggers function call::
@@ -1028,7 +1034,8 @@ class ExternalCommandManager:
         """
         service.acknowledge_problem(sticky, notify, persistent, author, comment, end_time=end_time)
 
-    def acknowledge_host_problem_expire(self, host, sticky, notify,
+    @staticmethod
+    def acknowledge_host_problem_expire(host, sticky, notify,
                                         persistent, end_time, author, comment):
         """Acknowledge a host problem with expire time for this acknowledgement
         Format of the line that triggers function call::
@@ -1072,7 +1079,8 @@ class ExternalCommandManager:
         contact.service_notification_period = notification_timeperiod
         self.sched.get_and_register_status_brok(contact)
 
-    def change_custom_contact_var(self, contact, varname, varvalue):
+    @staticmethod
+    def change_custom_contact_var(contact, varname, varvalue):
         """Change custom contact variable
         Format of the line that triggers function call::
 
@@ -1089,7 +1097,8 @@ class ExternalCommandManager:
         contact.modified_attributes |= DICT_MODATTR["MODATTR_CUSTOM_VARIABLE"].value
         contact.customs[varname.upper()] = varvalue
 
-    def change_custom_host_var(self, host, varname, varvalue):
+    @staticmethod
+    def change_custom_host_var(host, varname, varvalue):
         """Change custom host variable
         Format of the line that triggers function call::
 
@@ -1106,7 +1115,8 @@ class ExternalCommandManager:
         host.modified_attributes |= DICT_MODATTR["MODATTR_CUSTOM_VARIABLE"].value
         host.customs[varname.upper()] = varvalue
 
-    def change_custom_svc_var(self, service, varname, varvalue):
+    @staticmethod
+    def change_custom_svc_var(service, varname, varvalue):
         """Change custom service variable
         Format of the line that triggers function call::
 
@@ -1197,7 +1207,8 @@ class ExternalCommandManager:
         host.event_handler = CommandCall(self.commands, event_handler_command)
         self.sched.get_and_register_status_brok(host)
 
-    def change_host_modattr(self, host, value):
+    @staticmethod
+    def change_host_modattr(host, value):
         """Change host modified attributes
         Format of the line that triggers function call::
 
@@ -2781,7 +2792,8 @@ class ExternalCommandManager:
         """
         pass
 
-    def remove_host_acknowledgement(self, host):
+    @staticmethod
+    def remove_host_acknowledgement(host):
         """Remove an acknowledgment on a host
         Format of the line that triggers function call::
 
@@ -2793,7 +2805,8 @@ class ExternalCommandManager:
         """
         host.unacknowledge_problem()
 
-    def remove_svc_acknowledgement(self, service):
+    @staticmethod
+    def remove_svc_acknowledgement(service):
         """Remove an acknowledgment on a service
         Format of the line that triggers function call::
 
@@ -3537,7 +3550,8 @@ class ExternalCommandManager:
             self.conf.explode_global_conf()
             self.sched.get_and_register_update_program_status_brok()
 
-    def launch_svc_event_handler(self, service):
+    @staticmethod
+    def launch_svc_event_handler(service):
         """Launch event handler for a service
         Format of the line that triggers function call::
 
@@ -3549,7 +3563,8 @@ class ExternalCommandManager:
         """
         service.get_event_handlers(externalcmd=True)
 
-    def launch_host_event_handler(self, host):
+    @staticmethod
+    def launch_host_event_handler(host):
         """Launch event handler for a service
         Format of the line that triggers function call::
 

--- a/alignak/external_command.py
+++ b/alignak/external_command.py
@@ -75,7 +75,7 @@ from alignak.brok import Brok
 from alignak.misc.common import DICT_MODATTR
 
 
-class ExternalCommand:
+class ExternalCommand:  # pylint: disable=R0903
     """ExternalCommand class is only an object with a cmd_line attribute.
     All parsing and execution is done in manager
 

--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -177,7 +177,7 @@ class ArbiterInterface(GenericInterface):
                         try:
                             json.dumps(val)
                             env[prop] = val
-                        except Exception, exp:
+                        except TypeError, exp:
                             logger.debug('%s', exp)
                 lst.append(env)
         return res

--- a/alignak/http/broker_interface.py
+++ b/alignak/http/broker_interface.py
@@ -52,7 +52,7 @@ class BrokerInterface(GenericInterface):
         for inst in insts:
             try:
                 res.append({'module_alias': inst.get_name(), 'queue_size': inst.to_q.qsize()})
-            except Exception:
+            except Exception:  # pylint: disable=W0703
                 res.append({'module_alias': inst.get_name(), 'queue_size': 0})
 
         return res

--- a/alignak/http/generic_interface.py
+++ b/alignak/http/generic_interface.py
@@ -55,7 +55,7 @@ class GenericInterface(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def ping(self):
+    def ping(self):  # pylint: disable=R0201
         """Test the connection to the daemon. Returns: pong
 
         :return: string 'pong'
@@ -96,7 +96,7 @@ class GenericInterface(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def have_conf(self, magic_hash=None):
+    def have_conf(self, magic_hash=None):  # pylint: disable=W0613
         """Get the daemon cur_conf state
 
         :return: boolean indicating if the daemon has a conf
@@ -106,7 +106,7 @@ class GenericInterface(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def set_log_level(self, loglevel):
+    def set_log_level(self, loglevel):  # pylint: disable=R0201
         """Set the current log level in [NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL, UNKNOWN]
 
         :param loglevel: a value in one of the above
@@ -117,7 +117,7 @@ class GenericInterface(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def get_log_level(self):
+    def get_log_level(self):  # pylint: disable=R0201
         """Get the current log level in [NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL, UNKNOWN]
 
         :return: current log level
@@ -258,7 +258,7 @@ class GenericInterface(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def get_broks(self, bname):
+    def get_broks(self, bname):  # pylint: disable=W0613
         """Get broks from the daemon
 
         :return: Brok list serialized and b64encoded

--- a/alignak/log.py
+++ b/alignak/log.py
@@ -98,7 +98,7 @@ class BrokHandler(Handler):
             msg = self.format(record)
             brok = Brok('log', {'log': msg + '\n'})
             self._broker.add(brok)
-        except Exception:
+        except TypeError:
             self.handleError(record)
 
 
@@ -114,7 +114,7 @@ class ColorStreamHandler(StreamHandler):
             cprint(msg, colors[record.levelname])
         except UnicodeEncodeError:
             print msg.encode('ascii', 'ignore')
-        except Exception:
+        except TypeError:
             self.handleError(record)
 
 
@@ -301,7 +301,7 @@ if hasattr(sys.stdout, 'isatty'):
     logger.addHandler(CSH)
 
 
-def naglog_result(level, result, *args):
+def naglog_result(level, result):
     """
     Function use for old Nag compatibility. We to set format properly for this call only.
 

--- a/alignak/macroresolver.py
+++ b/alignak/macroresolver.py
@@ -137,7 +137,8 @@ class MacroResolver(Borg):
         # Try cache :)
         # self.cache = {}
 
-    def _get_macros(self, chain):
+    @staticmethod
+    def _get_macros(chain):
         """Get all macros of a chain
         Cut '$' char and create a dict with the following structure::
 
@@ -168,7 +169,8 @@ class MacroResolver(Borg):
             del macros['']
         return macros
 
-    def _get_value_from_element(self, elt, prop):
+    @staticmethod
+    def _get_value_from_element(elt, prop):
         """Get value from a element's property
         the property may be a function to call.
 
@@ -348,7 +350,8 @@ class MacroResolver(Borg):
         c_line = com.command.command_line
         return self.resolve_simple_macros_in_string(c_line, data, args=com.args)
 
-    def _get_type_of_macro(self, macros, clss):
+    @staticmethod
+    def _get_type_of_macro(macros, clss):
         r"""Set macros types
 
         Example::
@@ -396,7 +399,8 @@ class MacroResolver(Borg):
                     macros[macro]['class'] = cls
                     continue
 
-    def _resolve_argn(self, macro, args):
+    @staticmethod
+    def _resolve_argn(macro, args):
         """Get argument from macro name
         ie : $ARG3$ -> args[2]
 
@@ -474,7 +478,8 @@ class MacroResolver(Borg):
             return val
         return ''
 
-    def _get_long_date_time(self):
+    @staticmethod
+    def _get_long_date_time():
         """Get long date time
 
         Example : Fri 15 May 11:42:39 CEST 2009
@@ -486,7 +491,8 @@ class MacroResolver(Borg):
         """
         return time.strftime("%a %d %b %H:%M:%S %Z %Y").decode('UTF-8', 'ignore')
 
-    def _get_short_date_time(self):
+    @staticmethod
+    def _get_short_date_time():
         """Get short date time
 
         Example : 10-13-2000 00:30:28
@@ -498,7 +504,8 @@ class MacroResolver(Borg):
         """
         return time.strftime("%d-%m-%Y %H:%M:%S")
 
-    def _get_date(self):
+    @staticmethod
+    def _get_date():
         """Get date
 
         Example : 10-13-2000
@@ -510,7 +517,8 @@ class MacroResolver(Borg):
         """
         return time.strftime("%d-%m-%Y")
 
-    def _get_time(self):
+    @staticmethod
+    def _get_time():
         """Get date time
 
         Example : 00:30:28
@@ -522,7 +530,8 @@ class MacroResolver(Borg):
         """
         return time.strftime("%H:%M:%S")
 
-    def _get_timet(self):
+    @staticmethod
+    def _get_timet():
         """Get epoch time
 
         Example : 1437143291
@@ -549,7 +558,8 @@ class MacroResolver(Borg):
     _get_total_hosts_down = lambda s: s._tot_hosts_by_state('DOWN')
     _get_total_hosts_unreachable = lambda s: s._tot_hosts_by_state('UNREACHABLE')
 
-    def _get_total_hosts_unreachable_unhandled(self):
+    @staticmethod
+    def _get_total_hosts_unreachable_unhandled():
         """DOES NOTHING( Should get the number of unreachable hosts not handled)
 
         :return: 0 always
@@ -566,7 +576,8 @@ class MacroResolver(Borg):
         """
         return sum(1 for h in self.hosts if h.is_problem)
 
-    def _get_total_hosts_problems_unhandled(self):
+    @staticmethod
+    def _get_total_hosts_problems_unhandled():
         """DOES NOTHING( Should get the number of host problems not handled)
 
         :return: 0 always
@@ -594,7 +605,8 @@ class MacroResolver(Borg):
 
     _get_total_service_unknown = lambda s: s._tot_services_by_state('UNKNOWN')
 
-    def _get_total_services_warning_unhandled(self):
+    @staticmethod
+    def _get_total_services_warning_unhandled():
         """DOES NOTHING (Should get the number of warning services not handled)
 
         :return: 0 always
@@ -603,7 +615,8 @@ class MacroResolver(Borg):
         """
         return 0
 
-    def _get_total_services_critical_unhandled(self):
+    @staticmethod
+    def _get_total_services_critical_unhandled():
         """DOES NOTHING (Should get the number of critical services not handled)
 
         :return: 0 always
@@ -612,7 +625,8 @@ class MacroResolver(Borg):
         """
         return 0
 
-    def _get_total_services_unknown_unhandled(self):
+    @staticmethod
+    def _get_total_services_unknown_unhandled():
         """DOES NOTHING (Should get the number of unknown services not handled)
 
         :return: 0 always
@@ -629,7 +643,8 @@ class MacroResolver(Borg):
         """
         return sum(1 for s in self.services if s.is_problem)
 
-    def _get_total_service_problems_unhandled(self):
+    @staticmethod
+    def _get_total_service_problems_unhandled():
         """DOES NOTHING (Should get the number of service problems not handled)
 
         :return: 0 always
@@ -638,7 +653,8 @@ class MacroResolver(Borg):
         """
         return 0
 
-    def _get_process_start_time(self):
+    @staticmethod
+    def _get_process_start_time():
         """DOES NOTHING ( Should get process start time)
 
         :return: 0 always
@@ -647,7 +663,8 @@ class MacroResolver(Borg):
         """
         return 0
 
-    def _get_events_start_time(self):
+    @staticmethod
+    def _get_events_start_time():
         """DOES NOTHING ( Should get events start time)
 
         :return: 0 always

--- a/alignak/misc/datamanager.py
+++ b/alignak/misc/datamanager.py
@@ -61,7 +61,7 @@ from alignak.misc.sorter import hst_srv_sort, last_state_change_earlier
 from alignak.misc.filter import only_related_to
 
 
-class DataManager(object):
+class DataManager(object):  # pylint: disable=R0904
     """
     DataManager provide a set of accessor to Alignak objects
     (host, services) through a regenerator object.

--- a/alignak/misc/datamanager.py
+++ b/alignak/misc/datamanager.py
@@ -687,7 +687,8 @@ class DataManager(object):  # pylint: disable=R0904
         print "get_business_parents::Give elements", res
         return res
 
-    def guess_root_problems(self, obj):
+    @staticmethod
+    def guess_root_problems(obj):
         """
         Get the list of services with :
         * a state_id != 0 (not OK state)

--- a/alignak/misc/logevent.py
+++ b/alignak/misc/logevent.py
@@ -123,7 +123,7 @@ EVENT_TYPES = {
 }
 
 
-class LogEvent:
+class LogEvent:  # pylint: disable=R0903
     """Class for parsing event logs
     Populates self.data with the log type's properties
     """

--- a/alignak/misc/perfdata.py
+++ b/alignak/misc/perfdata.py
@@ -78,7 +78,7 @@ def guess_int_or_float(val):
         return None
 
 
-class Metric:
+class Metric:  # pylint: disable=R0903
     """
     Class providing a small abstraction for one metric of a Perfdatas class
     """
@@ -114,7 +114,7 @@ class Metric:
         return string
 
 
-class PerfDatas:
+class PerfDatas:  # pylint: disable=R0903
     """
     Class providing performance data extracted from a check output
     """

--- a/alignak/misc/perfdata.py
+++ b/alignak/misc/perfdata.py
@@ -74,7 +74,7 @@ def guess_int_or_float(val):
     """
     try:
         return to_best_int_float(val)
-    except Exception:
+    except (ValueError, TypeError):
         return None
 
 

--- a/alignak/misc/regenerator.py
+++ b/alignak/misc/regenerator.py
@@ -214,7 +214,7 @@ class Regenerator(object):  # pylint: disable=R0904
         for prop in data:
             setattr(item, prop, data[prop])
 
-    def all_done_linking(self, inst_id):
+    def all_done_linking(self, inst_id):  # pylint: disable=R0915
         """
         Link all data (objects) in a specific instance
 

--- a/alignak/misc/regenerator.py
+++ b/alignak/misc/regenerator.py
@@ -201,7 +201,8 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         if manage and self.want_brok(brok):
             return manage(brok)
 
-    def update_element(self, item, data):
+    @staticmethod
+    def update_element(item, data):
         """
         Update object attribute with value contained in data keys
 
@@ -245,7 +246,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
             inp_contactgroups = self.inp_contactgroups[inst_id]
             inp_services = self.inp_services[inst_id]
             inp_servicegroups = self.inp_servicegroups[inst_id]
-        except Exception, exp:
+        except KeyError, exp:
             print "Warning all done: ", exp
             return
 
@@ -661,7 +662,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         # Try to get the inp progress Hosts
         try:
             inp_hosts = self.inp_hosts[inst_id]
-        except Exception, exp:  # not good. we will cry in the program update
+        except KeyError, exp:  # not good. we will cry in the program update
             print "Not good!", exp
             return
 
@@ -690,7 +691,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         # Try to get the inp progress Hostgroups
         try:
             inp_hostgroups = self.inp_hostgroups[inst_id]
-        except Exception, exp:  # not good. we will cry in theprogram update
+        except KeyError, exp:  # not good. we will cry in theprogram update
             print "Not good!", exp
             return
 
@@ -720,7 +721,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         # Try to get the inp progress Hosts
         try:
             inp_services = self.inp_services[inst_id]
-        except Exception, exp:  # not good. we will cry in theprogram update
+        except KeyError, exp:  # not good. we will cry in theprogram update
             print "Not good!", exp
             return
 
@@ -749,7 +750,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         # Try to get the inp progress Hostgroups
         try:
             inp_servicegroups = self.inp_servicegroups[inst_id]
-        except Exception, exp:  # not good. we will cry in the program update
+        except KeyError, exp:  # not good. we will cry in the program update
             print "Not good!", exp
             return
 
@@ -836,7 +837,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         # Try to get the inp progress Contactgroups
         try:
             inp_contactgroups = self.inp_contactgroups[inst_id]
-        except Exception, exp:  # not good. we will cry in theprogram update
+        except KeyError, exp:  # not good. we will cry in theprogram update
             print "Not good!", exp
             return
 
@@ -1140,7 +1141,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         try:
             broker = self.brokers[broker_name]
             self.update_element(broker, data)
-        except Exception:
+        except KeyError:
             pass
 
     def manage_update_receiver_status_brok(self, brok):
@@ -1156,7 +1157,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         try:
             receiver = self.receivers[receiver_name]
             self.update_element(receiver, data)
-        except Exception:
+        except KeyError:
             pass
 
     def manage_update_reactionner_status_brok(self, brok):
@@ -1172,7 +1173,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         try:
             reactionner = self.reactionners[reactionner_name]
             self.update_element(reactionner, data)
-        except Exception:
+        except KeyError:
             pass
 
     def manage_update_poller_status_brok(self, brok):
@@ -1188,7 +1189,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         try:
             poller = self.pollers[poller_name]
             self.update_element(poller, data)
-        except Exception:
+        except KeyError:
             pass
 
     def manage_update_scheduler_status_brok(self, brok):
@@ -1205,7 +1206,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
             scheduler = self.schedulers[scheduler_name]
             self.update_element(scheduler, data)
             # print "S:", s
-        except Exception:
+        except KeyError:
             pass
 
 

--- a/alignak/misc/regenerator.py
+++ b/alignak/misc/regenerator.py
@@ -74,7 +74,7 @@ from alignak.util import safe_print
 from alignak.message import Message
 
 
-class Regenerator(object):
+class Regenerator(object):  # pylint: disable=R0904
     """
     Class for a Regenerator.
     It gets broks, and "regenerate" real objects from them

--- a/alignak/misc/regenerator.py
+++ b/alignak/misc/regenerator.py
@@ -214,7 +214,7 @@ class Regenerator(object):  # pylint: disable=R0904,R0902
         for prop in data:
             setattr(item, prop, data[prop])
 
-    def all_done_linking(self, inst_id):  # pylint: disable=R0915,R0914
+    def all_done_linking(self, inst_id):  # pylint: disable=R0915,R0914,R0912
         """
         Link all data (objects) in a specific instance
 

--- a/alignak/misc/regenerator.py
+++ b/alignak/misc/regenerator.py
@@ -214,7 +214,7 @@ class Regenerator(object):  # pylint: disable=R0904
         for prop in data:
             setattr(item, prop, data[prop])
 
-    def all_done_linking(self, inst_id):  # pylint: disable=R0915
+    def all_done_linking(self, inst_id):  # pylint: disable=R0915,R0914
         """
         Link all data (objects) in a specific instance
 

--- a/alignak/misc/regenerator.py
+++ b/alignak/misc/regenerator.py
@@ -74,7 +74,7 @@ from alignak.util import safe_print
 from alignak.message import Message
 
 
-class Regenerator(object):  # pylint: disable=R0904
+class Regenerator(object):  # pylint: disable=R0904,R0902
     """
     Class for a Regenerator.
     It gets broks, and "regenerate" real objects from them

--- a/alignak/modulesmanager.py
+++ b/alignak/modulesmanager.py
@@ -166,7 +166,7 @@ class ModulesManager(object):
                 inst.create_queues(self.manager)
 
             inst.init()
-        except Exception, err:
+        except Exception, err:  # pylint: disable=W0703
             logger.error("The instance %s raised an exception %s, I remove it!",
                          inst.get_name(), str(err))
             output = cStringIO.StringIO()
@@ -215,7 +215,7 @@ class ModulesManager(object):
                 if not isinstance(inst, BaseModule):
                     raise TypeError('Returned instance is not of type BaseModule (%s) !'
                                     % type(inst))
-            except Exception as err:
+            except Exception as err:  # pylint: disable=W0703
                 logger.error("The module %s raised an exception %s, I remove it! traceback=%s",
                              mod_conf.get_name(), err, traceback.format_exc())
             else:
@@ -298,7 +298,7 @@ class ModulesManager(object):
                 queue_size = 0
                 try:
                     queue_size = inst.to_q.qsize()
-                except Exception:
+                except Exception:  # pylint: disable=W0703
                     pass
                 if queue_size > self.max_queue_size:
                     logger.error("The external module %s got a too high brok queue size (%s > %s)!",

--- a/alignak/notification.py
+++ b/alignak/notification.py
@@ -145,11 +145,11 @@ class Notification(Action):  # pylint: disable=R0902
         # Set host_name and description from the ref
         try:
             self.host_name = self.ref.host_name
-        except Exception:
+        except AttributeError:
             self.host_name = host_name
         try:
             self.service_description = self.ref.service_description
-        except Exception:
+        except AttributeError:
             self.service_description = service_description
 
         if env is not None:

--- a/alignak/notification.py
+++ b/alignak/notification.py
@@ -115,8 +115,8 @@ class Notification(Action):  #pylint: disable=R0902
         'SERVICENOTIFICATIONID':    '_id'
     }
 
-    def __init__(self, _type='PROBLEM', status='scheduled', command='UNSET',
-                 command_call=None, ref=None, contact=None, t_to_go=0.0,
+    def __init__(self, _type='PROBLEM', status='scheduled',  # pylint: disable=R0913
+                 command='UNSET', command_call=None, ref=None, contact=None, t_to_go=0.0,
                  contact_name='', host_name='', service_description='',
                  reason_type=1, state=0, ack_author='', ack_data='',
                  escalated=False, contacts_notified=0,

--- a/alignak/notification.py
+++ b/alignak/notification.py
@@ -59,7 +59,7 @@ from alignak.property import BoolProp, IntegerProp, StringProp, FloatProp
 from alignak.autoslots import AutoSlots
 
 
-class Notification(Action):  #pylint: disable=R0902
+class Notification(Action):  # pylint: disable=R0902
     """Notification class, inherits from action class. Used to notify contacts
      and execute notification command defined in configuration
 

--- a/alignak/notification.py
+++ b/alignak/notification.py
@@ -59,7 +59,7 @@ from alignak.property import BoolProp, IntegerProp, StringProp, FloatProp
 from alignak.autoslots import AutoSlots
 
 
-class Notification(Action):
+class Notification(Action):  #pylint: disable=R0902
     """Notification class, inherits from action class. Used to notify contacts
      and execute notification command defined in configuration
 

--- a/alignak/objects/command.py
+++ b/alignak/objects/command.py
@@ -58,7 +58,7 @@ from alignak.property import StringProp, IntegerProp, BoolProp
 from alignak.autoslots import AutoSlots
 
 
-class DummyCommand(object):
+class DummyCommand(object):  # pylint: disable=R0903
     """
     Class used to set __autoslots__ because can't set it
     in same class you use

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -886,7 +886,8 @@ class Config(Item):  # pylint: disable=R0904,R0902
         # Change Nagios2 names to Nagios3 ones (before using them)
         self.old_properties_names_to_new()
 
-    def _cut_line(self, line):
+    @staticmethod
+    def _cut_line(line):
         """Split the line on whitespaces and remove empty chunks
 
         :param line: the line to split
@@ -899,7 +900,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         res = [elt for elt in tmp if elt != '']
         return res
 
-    def read_config(self, files):
+    def read_config(self, files):  # pylint: disable=R0912
         """Read and parse main configuration files
         (specified with -c option to the Arbiter)
         and put them into a StringIO object
@@ -1012,9 +1013,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         res.close()
         return config
 
-#        self.read_config_buf(res)
-
-    def read_config_buf(self, buf):
+    def read_config_buf(self, buf):  # pylint: disable=R0912
         """The config buffer (previously returned by Config.read_config())
 
         :param buf: buffer containing all data from config files
@@ -1138,7 +1137,8 @@ class Config(Item):  # pylint: disable=R0904,R0902
 
         return objects
 
-    def add_ghost_objects(self, raw_objects):
+    @staticmethod
+    def add_ghost_objects(raw_objects):
         """Add fake command objects for internal processing ; bp_rule, _internal_host_up, _echo
 
         :param raw_objects: Raw config objects dict
@@ -2014,7 +2014,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         #      r &= False
         return valid
 
-    def is_correct(self):
+    def is_correct(self):  # pylint: disable=R0912
         """Check if all elements got a good configuration
 
         :return: True if the configuration is correct else False
@@ -2177,12 +2177,13 @@ class Config(Item):  # pylint: disable=R0904,R0902
         for err in self.configuration_errors:
             logger.error(err)
 
-    def create_packs(self, nb_packs):  # pylint: disable=R0915,R0914,R0912
+    def create_packs(self, nb_packs):  # pylint: disable=R0915,R0914,R0912,W0613
         """Create packs of hosts and services (all dependencies are resolved)
         It create a graph. All hosts are connected to their
         parents, and hosts without parent are connected to host 'root'.
         services are link to the host. Dependencies are managed
-        REF: doc/pack-creation.pn
+        REF: doc/pack-creation.png
+        TODO : Check why np_packs is not used.
 
         :param nb_packs: the number of packs to create (number of scheduler basically)
         :type nb_packs: int

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -1309,8 +1309,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
 
         # print "Contacts"
         # link contacts with timeperiods and commands
-        self.contacts.linkify(self.timeperiods, self.commands,
-                              self.notificationways)
+        self.contacts.linkify(self.notificationways)
 
         # print "Timeperiods"
         # link timeperiods with timeperiods (exclude part)

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2177,7 +2177,7 @@ class Config(Item):  # pylint: disable=R0904
         for err in self.configuration_errors:
             logger.error(err)
 
-    def create_packs(self, nb_packs):
+    def create_packs(self, nb_packs):  # pylint: disable=R0915
         """Create packs of hosts and services (all dependencies are resolved)
         It create a graph. All hosts are connected to their
         parents, and hosts without parent are connected to host 'root'.

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -127,7 +127,7 @@ NO_LONGER_USED = ('This parameter is not longer take from the main file, but mus
 NOT_INTERESTING = 'We do not think such an option is interesting to manage.'
 
 
-class Config(Item):
+class Config(Item):  # pylint: disable=R0904
     """Config is the class to read, load and manipulate the user
  configuration. It read a main cfg (alignak.cfg) and get all information
  from it. It create objects, make link between them, clean them, and cut

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2387,7 +2387,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
                            "Some hosts have been "
                            "ignored" % (len(self.hosts), nb_elements_all_realms))
 
-    def cut_into_parts(self):  #pylint: disable=R0912
+    def cut_into_parts(self):  # pylint: disable=R0912
         """Cut conf into part for scheduler dispatch.
         Basically it provide a set of host/services for each scheduler that
         have no dependencies between them

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -127,7 +127,7 @@ NO_LONGER_USED = ('This parameter is not longer take from the main file, but mus
 NOT_INTERESTING = 'We do not think such an option is interesting to manage.'
 
 
-class Config(Item):  # pylint: disable=R0904
+class Config(Item):  # pylint: disable=R0904,R0902
     """Config is the class to read, load and manipulate the user
  configuration. It read a main cfg (alignak.cfg) and get all information
  from it. It create objects, make link between them, clean them, and cut

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2177,7 +2177,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         for err in self.configuration_errors:
             logger.error(err)
 
-    def create_packs(self, nb_packs):  # pylint: disable=R0915,R0914
+    def create_packs(self, nb_packs):  # pylint: disable=R0915,R0914,R0912
         """Create packs of hosts and services (all dependencies are resolved)
         It create a graph. All hosts are connected to their
         parents, and hosts without parent are connected to host 'root'.
@@ -2387,7 +2387,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
                            "Some hosts have been "
                            "ignored" % (len(self.hosts), nb_elements_all_realms))
 
-    def cut_into_parts(self):
+    def cut_into_parts(self):  #pylint: disable=R0912
         """Cut conf into part for scheduler dispatch.
         Basically it provide a set of host/services for each scheduler that
         have no dependencies between them

--- a/alignak/objects/contact.py
+++ b/alignak/objects/contact.py
@@ -318,26 +318,16 @@ class Contacts(Items):
     name_property = "contact_name"
     inner_class = Contact
 
-    def linkify(self, timeperiods, commands, notificationways):
+    def linkify(self, notificationways):
         """Create link between objects::
 
-         * contacts -> timeperiods
-         * contacts -> commands
          * contacts -> notificationways
 
-        :param timeperiods: timeperiods to link
-        :type timeperiods: alignak.objects.timeperiod.Timeperiods
-        :param commands: commands to link
-        :type commands: alignak.objects.command.Commands
         :param notificationways: notificationways to link
         :type notificationways: alignak.objects.notificationway.Notificationways
         :return: None
         TODO: Clean this function
         """
-        # self.linkify_with_timeperiods(timeperiods, 'service_notification_period')
-        # self.linkify_with_timeperiods(timeperiods, 'host_notification_period')
-        # self.linkify_command_list_with_commands(commands, 'service_notification_commands')
-        # self.linkify_command_list_with_commands(commands, 'host_notification_commands')
         self.linkify_with_notificationways(notificationways)
 
     def linkify_with_notificationways(self, notificationways):

--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -79,7 +79,7 @@ from alignak.eventhandler import EventHandler
 from alignak.log import logger, naglog_result
 
 
-class Host(SchedulingItem):
+class Host(SchedulingItem):  # pylint: disable=R0904
     """Host class implements monitoring concepts for host.
     For example it defines parents, check_interval, check_command  etc.
     """

--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -1214,9 +1214,10 @@ class Hosts(Items):
     name_property = "host_name"  # use for the search by name
     inner_class = Host  # use for know what is in items
 
-    def linkify(self, timeperiods=None, commands=None, contacts=None, realms=None,
-                resultmodulations=None, businessimpactmodulations=None, escalations=None,
-                hostgroups=None, triggers=None, checkmodulations=None, macromodulations=None):
+    def linkify(self, timeperiods=None, commands=None, contacts=None,  # pylint: disable=R0913
+                realms=None, resultmodulations=None, businessimpactmodulations=None,
+                escalations=None, hostgroups=None, triggers=None,
+                checkmodulations=None, macromodulations=None):
         """Create link between objects::
 
          * hosts -> timeperiods

--- a/alignak/objects/hostextinfo.py
+++ b/alignak/objects/hostextinfo.py
@@ -16,7 +16,7 @@
 # GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
+# along with Alignak.  If not, see <http://www.gnu.org  /licenses/>.
 #
 #
 # This file incorporates work covered by the following copyright and
@@ -137,7 +137,8 @@ class HostsExtInfo(Items):
                 # Fusion
                 self.merge_extinfo(host, extinfo)
 
-    def merge_extinfo(self, host, extinfo):
+    @staticmethod
+    def merge_extinfo(host, extinfo):
         """Merge extended host information into a host
 
         :param host: the host to edit

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -59,6 +59,7 @@ This class is a base class for nearly all configuration
 elements like service, hosts or contacts.
 """
 # pylint: disable=C0302
+# pylint: disable=R0904
 import time
 import itertools
 import warnings

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -830,7 +830,7 @@ class Item(object):
                                                            tname))
         self.triggers = new_triggers
 
-    def dump(self, dfile=None):
+    def dump(self, dfile=None):  # pylint: disable=W0613
         """
         Dump properties
 
@@ -888,7 +888,8 @@ class Items(object):
         self.configuration_errors = []
         self.add_items(items, index_items)
 
-    def get_source(self, item):
+    @staticmethod
+    def get_source(item):
         """
         Get source, so with what system we import this item
 
@@ -1460,7 +1461,8 @@ class Items(object):
                         continue
                 i.business_impact_modulations = new_business_impact_modulations
 
-    def explode_contact_groups_into_contacts(self, item, contactgroups):
+    @staticmethod
+    def explode_contact_groups_into_contacts(item, contactgroups):
         """
         Get all contacts of contact_groups and put them in contacts container
 
@@ -1522,7 +1524,8 @@ class Items(object):
                 # Got a real one, just set it :)
                 setattr(i, prop, timeperiod)
 
-    def create_commandcall(self, prop, commands, command):
+    @staticmethod
+    def create_commandcall(prop, commands, command):
         """
         Create commandCall object with command
 
@@ -1671,7 +1674,8 @@ class Items(object):
                     item.configuration_errors.append(err)
             item.modules = new_modules
 
-    def evaluate_hostgroup_expression(self, expr, hosts, hostgroups, look_in='hostgroups'):
+    @staticmethod
+    def evaluate_hostgroup_expression(expr, hosts, hostgroups, look_in='hostgroups'):
         """
         Evaluate hostgroup expression
 
@@ -1706,7 +1710,8 @@ class Items(object):
         # HOOK DBG
         return list(set_res)
 
-    def get_hosts_from_hostgroups(self, hgname, hostgroups):
+    @staticmethod
+    def get_hosts_from_hostgroups(hgname, hostgroups):
         """
         Get hosts of hostgroups
 

--- a/alignak/objects/satellitelink.py
+++ b/alignak/objects/satellitelink.py
@@ -106,7 +106,7 @@ class SatelliteLink(Item):
         if hasattr(self, 'port'):
             try:
                 self.arb_satmap['port'] = int(self.port)
-            except Exception:
+            except ValueError:
                 pass
 
     def get_name(self):

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -61,6 +61,7 @@ will find all scheduling related functions, like the schedule
 or the consume_check. It's a very important class!
 """
 # pylint: disable=C0302
+# pylint: disable=R0904
 import re
 import random
 import time

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -82,7 +82,7 @@ from alignak.comment import Comment
 from alignak.log import logger
 
 
-class SchedulingItem(Item):  #pylint: disable=R0902
+class SchedulingItem(Item):  # pylint: disable=R0902
     """SchedulingItem class provide method for Scheduler to handle Service or Host objects
 
     """

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -1276,7 +1276,7 @@ class SchedulingItem(Item):
             if self.state != self.state_before_hard_unknown_reach_phase:
                 self.was_in_hard_unknown_reach_phase = False
 
-    def consume_result(self, chk):
+    def consume_result(self, chk):  # pylint: disable=R0915
         """Consume a check return and send action in return
         main function of reaction of checks like raise notifications
 

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -82,7 +82,7 @@ from alignak.comment import Comment
 from alignak.log import logger
 
 
-class SchedulingItem(Item):
+class SchedulingItem(Item):  #pylint: disable=R0902
     """SchedulingItem class provide method for Scheduler to handle Service or Host objects
 
     """

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -1276,7 +1276,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
             if self.state != self.state_before_hard_unknown_reach_phase:
                 self.was_in_hard_unknown_reach_phase = False
 
-    def consume_result(self, chk):  # pylint: disable=R0915
+    def consume_result(self, chk):  # pylint: disable=R0915,R0912
         """Consume a check return and send action in return
         main function of reaction of checks like raise notifications
 
@@ -2244,7 +2244,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
                 self.create_business_rules(hosts, services, running=True)
                 state = self.business_rule.get_state()
                 check.output = self.get_business_rule_output()
-            except Exception, err:
+            except Exception, err:  # pylint: disable=W0703
                 # Notifies the error, and return an UNKNOWN state.
                 check.output = "Error while re-evaluating business rule: %s" % err
                 logger.debug("[%s] Error while re-evaluating business rule:\n%s",
@@ -2305,7 +2305,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         for trigger in self.triggers:
             try:
                 trigger.eval(self)
-            except Exception:
+            except Exception:  # pylint: disable=W0703
                 logger.error(
                     "We got an exception from a trigger on %s for %s",
                     self.get_full_name().decode('utf8', 'ignore'), str(traceback.format_exc())
@@ -2418,7 +2418,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: True
         :rtype: bool
         """
-        return True
+        pass
 
     def raise_freshness_log_entry(self, t_stale_by, t_threshold):
         """Raise freshness alert entry (warning level)
@@ -2492,7 +2492,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: list containing the service and the linked host
         :rtype: list
         """
-        return []
+        pass
 
     def get_data_for_event_handler(self):
         """Get data for an event handler
@@ -2500,7 +2500,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: list containing a single item (this one)
         :rtype: list
         """
-        return []
+        pass
 
     def get_data_for_notifications(self, contact, notif):
         """Get data for a notification
@@ -2512,7 +2512,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: list
         :rtype: list
         """
-        return []
+        pass
 
     def set_impact_state(self):
         """We just go an impact, so we go unreachable
@@ -2538,7 +2538,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: return 0
         :rtype: int
         """
-        return 0
+        pass
 
     def set_unreachable(self):
         """
@@ -2583,7 +2583,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: True if ONE of the above condition was met, otherwise False
         :rtype: bool
         """
-        return False
+        pass
 
     def notification_is_blocked_by_contact(self, notif, contact):
         """Check if the notification is blocked by this contact.
@@ -2595,7 +2595,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: True if the notification is blocked, False otherwise
         :rtype: bool
         """
-        return False
+        pass
 
     def is_correct(self):
 

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -66,6 +66,7 @@
 """ This Class is the service one, s it manage all service specific thing.
 If you look at the scheduling part, look at the scheduling item class"""
 # pylint: disable=C0302
+# pylint: disable=R0904
 import time
 import re
 

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -1282,7 +1282,7 @@ class Services(Items):
         key = (host_name, sdescr)
         return self.name_to_item.get(key, None)
 
-    def linkify(self, hosts, commands, timeperiods, contacts,
+    def linkify(self, hosts, commands, timeperiods, contacts,  # pylint: disable=R0913
                 resultmodulations, businessimpactmodulations, escalations,
                 servicegroups, triggers, checkmodulations, macromodulations):
         """Create link between objects::

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -1619,7 +1619,8 @@ class Services(Items):
             # Adds concrete instance
             self.add_item(new_s)
 
-    def register_service_into_servicegroups(self, service, servicegroups):
+    @staticmethod
+    def register_service_into_servicegroups(service, servicegroups):
         """
         Registers a service into the service groups declared in its
         `servicegroups` attribute.
@@ -1642,7 +1643,8 @@ class Services(Items):
                 for servicegroup in sgs:
                     servicegroups.add_member([shname, sname], servicegroup.strip())
 
-    def register_service_dependencies(self, service, servicedependencies):
+    @staticmethod
+    def register_service_dependencies(service, servicedependencies):
         """
         Registers a service dependencies.
 

--- a/alignak/objects/serviceextinfo.py
+++ b/alignak/objects/serviceextinfo.py
@@ -135,7 +135,8 @@ class ServicesExtInfo(Items):
                     # Fusion
                     self.merge_extinfo(serv, extinfo)
 
-    def merge_extinfo(self, service, extinfo):
+    @staticmethod
+    def merge_extinfo(service, extinfo):
         """Merge extended host information into a service
 
         :param service: the service to edit

--- a/alignak/objects/timeperiod.py
+++ b/alignak/objects/timeperiod.py
@@ -605,7 +605,7 @@ class Timeperiod(Item):
 
         return string
 
-    def resolve_daterange(self, dateranges, entry):  # pylint: disable=R0911
+    def resolve_daterange(self, dateranges, entry):  # pylint: disable=R0911,R0915
         """
         Try to solve dateranges (special cases)
 

--- a/alignak/objects/timeperiod.py
+++ b/alignak/objects/timeperiod.py
@@ -198,13 +198,10 @@ class Timeperiod(Item):
         """
         return getattr(self, 'timeperiod_name', 'unknown_timeperiod')
 
-    def get_unresolved_properties_by_inheritance(self, items):
+    def get_unresolved_properties_by_inheritance(self):
         """
         Fill full properties with template if needed for the
         unresolved values (example: sunday ETCETC)
-
-        :param items: The Timeperiods object.
-        :type items: object
         :return: None
         """
         # Ok, I do not have prop, Maybe my templates do?
@@ -605,7 +602,7 @@ class Timeperiod(Item):
 
         return string
 
-    def resolve_daterange(self, dateranges, entry):  # pylint: disable=R0911,R0915
+    def resolve_daterange(self, dateranges, entry):  # pylint: disable=R0911,R0915,R0912
         """
         Try to solve dateranges (special cases)
 
@@ -992,7 +989,7 @@ class Timeperiods(Items):
         # And now apply inheritance for unresolved properties
         # like the dateranges in fact
         for timeperiod in self:
-            timeperiod.get_unresolved_properties_by_inheritance(self.items)
+            timeperiod.get_unresolved_properties_by_inheritance()
 
     def is_correct(self):
         """

--- a/alignak/objects/trigger.py
+++ b/alignak/objects/trigger.py
@@ -115,7 +115,7 @@ class Trigger(Item):
         del env["ctx"]
         try:
             exec code in env  # pylint: disable=W0122
-        except Exception as err:
+        except Exception as err:  # pylint: disable=W0703
             set_value(ctx, "UNKNOWN: Trigger error: %s" % err, "", 3)
             logger.error('%s Trigger %s failed: %s ; '
                          '%s', ctx.host_name, self.trigger_name, err, traceback.format_exc())
@@ -186,7 +186,8 @@ class Triggers(Items):
         for i in self:
             i.compile()
 
-    def load_objects(self, conf):
+    @staticmethod
+    def load_objects(conf):
         """Set hosts and services from conf as global var
 
         :param conf: alignak configuration

--- a/alignak/property.py
+++ b/alignak/property.py
@@ -83,7 +83,7 @@ class Property(object):
 
     """
 
-    def __init__(self, default=NONE_OBJECT, class_inherit=None,
+    def __init__(self, default=NONE_OBJECT, class_inherit=None,  # pylint: disable=R0913
                  unmanaged=False, _help='', no_slots=False,
                  fill_brok=None, conf_send_preparation=None,
                  brok_transformation=None, retention=False,

--- a/alignak/property.py
+++ b/alignak/property.py
@@ -159,7 +159,7 @@ class Property(object):
         self.keep_empty = keep_empty
         self.special = special
 
-    def pythonize(self, val):
+    def pythonize(self, val):  # pylint: disable=R0201
         """Generic pythonize method
 
         :param val: value to python

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -839,7 +839,7 @@ class Satellite(BaseSatellite):  # pylint: disable=R0902
         import socket
         socket.setdefaulttimeout(None)
 
-    def setup_new_conf(self):  # pylint: disable=R0915
+    def setup_new_conf(self):  # pylint: disable=R0915,R0912
         """Setup new conf received from Arbiter
 
         :return: None

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -154,7 +154,7 @@ class BaseSatellite(Daemon):
         raise NotImplementedError()
 
 
-class Satellite(BaseSatellite):  #pylint: disable=R0902
+class Satellite(BaseSatellite):  # pylint: disable=R0902
     """Satellite class.
     Subclassed by Receiver, Reactionner and Poller
 

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -839,7 +839,7 @@ class Satellite(BaseSatellite):
         import socket
         socket.setdefaulttimeout(None)
 
-    def setup_new_conf(self):
+    def setup_new_conf(self):  # pylint: disable=R0915
         """Setup new conf received from Arbiter
 
         :return: None

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -154,7 +154,7 @@ class BaseSatellite(Daemon):
         raise NotImplementedError()
 
 
-class Satellite(BaseSatellite):
+class Satellite(BaseSatellite):  #pylint: disable=R0902
     """Satellite class.
     Subclassed by Receiver, Reactionner and Poller
 

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -93,7 +93,7 @@ from alignak.stats import statsmgr
 from alignak.misc.common import DICT_MODATTR
 
 
-class Scheduler(object):  #pylint: disable=R0902
+class Scheduler(object):  # pylint: disable=R0902
     """Scheduler class. Mostly handle scheduling items (host service) to schedule check
     raise alert, enter downtime etc."""
 

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -66,6 +66,7 @@ The major part of monitoring "intelligence" is in this module.
 
 """
 # pylint: disable=C0302
+# pylint: disable=R0904
 import time
 import os
 import cStringIO

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -93,7 +93,7 @@ from alignak.stats import statsmgr
 from alignak.misc.common import DICT_MODATTR
 
 
-class Scheduler(object):
+class Scheduler(object):  #pylint: disable=R0902
     """Scheduler class. Mostly handle scheduling items (host service) to schedule check
     raise alert, enter downtime etc."""
 

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -319,7 +319,7 @@ class Scheduler(object):  # pylint: disable=R0902
                 string = 'BROK: %s:%s\n' % (brok._id, brok.type)
                 file_h.write(string)
             file_h.close()
-        except Exception, exp:
+        except OSError, exp:
             logger.error("Error in writing the dump file %s : %s", path, str(exp))
 
     def dump_config(self):
@@ -335,7 +335,7 @@ class Scheduler(object):  # pylint: disable=R0902
             file_h.write('Scheduler config DUMP at %d\n' % time.time())
             self.conf.dump(file_h)
             file_h.close()
-        except Exception, exp:
+        except (OSError, IndexError), exp:
             logger.error("Error in writing the dump file %s : %s", path, str(exp))
 
     def load_external_command(self, ecm):
@@ -523,7 +523,7 @@ class Scheduler(object):  # pylint: disable=R0902
                 fun = getattr(inst, full_hook_name)
                 try:
                     fun(self)
-                except Exception, exp:
+                except Exception, exp:  # pylint: disable=W0703
                     logger.error("The instance %s raise an exception %s."
                                  "I disable it and set it to restart it later",
                                  inst.get_name(), str(exp))
@@ -946,7 +946,8 @@ class Scheduler(object):  # pylint: disable=R0902
             return t_dict[s_type]
         return None
 
-    def is_connection_try_too_close(self, elt):
+    @staticmethod
+    def is_connection_try_too_close(elt):
         """Check if last connection was too early for element
 
         :param elt: element to check
@@ -1106,7 +1107,7 @@ class Scheduler(object):  # pylint: disable=R0902
                     # now go the cpickle pass, and catch possible errors from it
                     try:
                         results = cPickle.loads(results)
-                    except Exception, exp:
+                    except Exception, exp:  # pylint: disable=W0703
                         logger.error('Cannot load passive results from satellite %s : %s',
                                      poll['name'], str(exp))
                         continue
@@ -1303,7 +1304,7 @@ class Scheduler(object):  # pylint: disable=R0902
             all_data['services'][(serv.host.host_name, serv.service_description)] = s_dict
         return all_data
 
-    def restore_retention_data(self, data):
+    def restore_retention_data(self, data):  # pylint: disable=R0912
         """Restore retention data
 
         Data coming from retention will override data coming from configuration

--- a/alignak/shinken_import_hook.py
+++ b/alignak/shinken_import_hook.py
@@ -17,7 +17,7 @@ class Finder(object):
           https://docs.python.org/2/library/sys.html#sys.meta_path
     """
 
-    def find_module(self, fullname, path=None):
+    def find_module(self, fullname, path=None):  # pylint: disable=W0613
         """Find module based on the fullname and path given
 
         :param fullname: module full name
@@ -31,7 +31,8 @@ class Finder(object):
         if fullname in hookable_names or fullname.startswith('shinken.'):
             return self
 
-    def load_module(self, name):
+    @staticmethod
+    def load_module(name):
         """Load module
 
         :param name: module to load

--- a/alignak/util.py
+++ b/alignak/util.py
@@ -68,7 +68,7 @@ from alignak.version import VERSION
 
 try:
     SAFE_STDOUT = (sys.stdout.encoding == 'UTF-8')
-except Exception, exp:
+except AttributeError, exp:
     logger.error('Encoding detection error= %s', exp)
     SAFE_STDOUT = False
 
@@ -179,7 +179,7 @@ def jsonify_r(obj):
         try:
             json.dumps(obj)
             return obj
-        except Exception:
+        except TypeError:
             return None
     properties = cls.properties.keys()
     if hasattr(cls, 'running_properties'):
@@ -196,7 +196,7 @@ def jsonify_r(obj):
                 val = sorted(val)
             json.dumps(val)
             res[prop] = val
-        except Exception:
+        except TypeError:
             if isinstance(val, list):
                 lst = []
                 for subval in val:
@@ -204,7 +204,7 @@ def jsonify_r(obj):
                     if o_type == 'CommandCall':
                         try:
                             lst.append(subval.call)
-                        except Exception:
+                        except AttributeError:
                             pass
                         continue
                     if o_type and hasattr(subval, o_type + '_name'):
@@ -218,7 +218,7 @@ def jsonify_r(obj):
                 if o_type == 'CommandCall':
                     try:
                         res[prop] = val.call
-                    except Exception:
+                    except AttributeError:
                         pass
                     continue
                 if o_type and hasattr(val, o_type + '_name'):
@@ -539,7 +539,7 @@ def from_float_to_int(val):
 # ref is the item like a service, and value
 # if the value to preprocess
 
-def to_list_string_of_names(ref, tab):
+def to_list_string_of_names(ref, tab):  # pylint: disable=W0613
     """Convert list into a comma separated list of element name
 
     :param ref: Not used
@@ -552,7 +552,7 @@ def to_list_string_of_names(ref, tab):
     return ",".join([e.get_name() for e in tab])
 
 
-def to_list_of_names(ref, tab):
+def to_list_of_names(ref, tab):  # pylint: disable=W0613
     """Convert list into a list of element name
 
     :param ref: Not used
@@ -565,7 +565,7 @@ def to_list_of_names(ref, tab):
     return [e.get_name() for e in tab]
 
 
-def to_name_if_possible(ref, value):
+def to_name_if_possible(ref, value):  # pylint: disable=W0613
     """Try to get value name (call get_name method)
 
     :param ref: Not used
@@ -580,7 +580,7 @@ def to_name_if_possible(ref, value):
     return ''
 
 
-def to_hostnames_list(ref, tab):
+def to_hostnames_list(ref, tab):  # pylint: disable=W0613
     """Convert Host list into a list of  host_name
 
     :param ref: Not used
@@ -597,7 +597,7 @@ def to_hostnames_list(ref, tab):
     return res
 
 
-def to_svc_hst_distinct_lists(ref, tab):
+def to_svc_hst_distinct_lists(ref, tab):  # pylint: disable=W0613
     """create a dict with 2 lists::
 
     * services: all services of the tab
@@ -650,7 +650,7 @@ def get_obj_name(obj):
     return obj.get_name()
 
 
-def get_obj_name_two_args_and_void(obj, value):
+def get_obj_name_two_args_and_void(obj, value):  # pylint: disable=W0613
     """Get value name (call get_name) if not a string
 
     :param obj: Not used
@@ -676,7 +676,7 @@ def get_obj_full_name(obj):
     """
     try:
         return obj.get_full_name()
-    except Exception:
+    except AttributeError:
         return obj.get_name()
 
 
@@ -957,7 +957,7 @@ def expect_file_dirs(root, path):
         if not os.path.exists(path):
             try:
                 os.mkdir(path)
-            except Exception:
+            except OSError:
                 return False
         tmp_dir = path
     return True
@@ -968,7 +968,7 @@ def expect_file_dirs(root, path):
 # Return callback functions which are passed host or service instances, and
 # should return a boolean value that indicates if the instance matched the
 # filter
-def filter_any(name):
+def filter_any(name):  # pylint: disable=W0613
     """Filter for host
     Filter nothing
 
@@ -978,14 +978,14 @@ def filter_any(name):
     :rtype: bool
     """
 
-    def inner_filter(host):
+    def inner_filter(host):  # pylint: disable=W0613
         """Inner filter for host. Accept all"""
         return True
 
     return inner_filter
 
 
-def filter_none(name):
+def filter_none(name):  # pylint: disable=W0613
     """Filter for host
     Filter all
 
@@ -995,7 +995,7 @@ def filter_none(name):
     :rtype: bool
     """
 
-    def inner_filter(host):
+    def inner_filter(host):  # pylint: disable=W0613
         """Inner filter for host. Accept nothing"""
         return False
 

--- a/alignak/worker.py
+++ b/alignak/worker.py
@@ -79,9 +79,9 @@ class Worker(object):
     _timeout = None
     _control_q = None
 
-    def __init__(self, _id, slave_q, returns_queue, processes_by_worker, mortal=True, timeout=300,
-                 max_plugins_output_length=8192, target=None, loaded_into='unknown',
-                 http_daemon=None):
+    def __init__(self, _id, slave_q, returns_queue, processes_by_worker,  # pylint: disable=W0613
+                 mortal=True, timeout=300, max_plugins_output_length=8192, target=None,
+                 loaded_into='unknown', http_daemon=None):
         self._id = self.__class__._id
         self.__class__._id += 1
 
@@ -106,7 +106,8 @@ class Worker(object):
         else:  # windows forker do not like pickle http/lock
             self.http_daemon = None
 
-    def _prework(self, real_work, *args):
+    @staticmethod
+    def _prework(real_work, *args):
         """Simply drop the BrokHandler before doing the real_work"""
         for handler in list(logger.handlers):
             if isinstance(handler, BrokHandler):
@@ -382,7 +383,7 @@ class Worker(object):
                 if cmsg.get_type() == 'Die':
                     logger.debug("[%d] Dad say we are dying...", self._id)
                     break
-            except Exception:
+            except Exception:  # pylint: disable=W0703
                 pass
 
             # Look if we are dying, and if we finish all current checks

--- a/test/alignak_test.py
+++ b/test/alignak_test.py
@@ -214,7 +214,7 @@ class AlignakTest(unittest.TestCase):
         self.conf.show_errors()
         self.dispatcher = Dispatcher(self.conf, self.me)
 
-        scheddaemon = Alignak(None, False, False, False, None, None)
+        scheddaemon = Alignak(None, False, False, False, None)
         self.scheddaemon = scheddaemon
         self.sched = scheddaemon.sched
         scheddaemon.load_modules_manager()

--- a/test/test_scheduler_init.py
+++ b/test/test_scheduler_init.py
@@ -71,7 +71,7 @@ class testSchedulerInit(AlignakTest):
 
     def create_daemon(self):
         cls = Alignak
-        return cls(daemons_config[cls], False, True, False, None, '')
+        return cls(daemons_config[cls], False, True, False, None)
 
     def _get_subproc_data(self, proc):
         try:


### PR DESCRIPTION
This should be the last PR about pylint for a while.

```
:too-many-branches (R0912): *Too many branches (%s/%s)*
  Used when a function or method has too many branches, making it hard to
  follow. This message belongs to the design checker.

:access-member-before-definition (E0203): *Access to member %r before its definition line %s*
  Used when an instance member is accessed before it's actually assigned. This
  message belongs to the classes checker.

:unused-argument (W0613): *Unused argument %r*
  Used when a function or method argument is not used. This message belongs to
  the variables checker.

:broad-except (W0703): *Catching too general exception %s*
  Used when an except catches a too general exception, possibly burying
  unrelated errors. This message belongs to the exceptions checker.

:no-self-use (R0201): *Method could be a function*
  Used when a method doesn't use its bound instance, and so could be written as
  a function. This message belongs to the classes checker.

```

Related to #262 #87 and naparuba/shinken#1393