### PR TITLE
Fixes #365: missing service_description for a service breaks the configuration loading

### DIFF
--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -420,7 +420,9 @@ class Host(SchedulingItem):  # pylint: disable=R0904
         :return: True if is excluded, otherwise False
         :rtype: bool
         """
-        return self.is_excluded_for_sdesc(service.service_description, service.is_tpl())
+        return self.is_excluded_for_sdesc(
+            getattr(self, 'service_description', None), service.is_tpl()
+        )
 
     def is_excluded_for_sdesc(self, sdesc, is_tpl=False):
         """ Check whether this host should have the passed service *description*


### PR DESCRIPTION
I did not included any test because of the current tests refactoring ... 

But when running the arbiter with the -V options, I got:
```
[1474890355] ERROR: [Alignak] [service::generic-windows-host] service_description property not set
[1474890355] ERROR: [Alignak] [service::generic-windows-host] a service has been defined without service_description in /home/alignak/conf/host.cfg:14
[1474890355] ERROR: [Alignak] [service::generic-windows-host] a service item has been defined without unique_key in /home/alignak/conf/host.cfg:14
[1474890355] ERROR: [Alignak] [items] In generic-windows-host is incorrect ; from /home/alignak/conf_cnaf/conf/host.cfg:14
[1474890355] ERROR: [Alignak] 	services conf incorrect!!

```

instead of the exception !