### PR TITLE
Develop+logs

### DIFF
--- a/alignak/bin/alignak_arbiter.py
+++ b/alignak/bin/alignak_arbiter.py
@@ -65,8 +65,8 @@ def main():
     """
     args = parse_daemon_args(True)
 
-    if not args.config_files:
-        print "Requires at least one config file (option -c/--config"
+    if not args.monitoring_files:
+        print "Requires at least one monitoring configuration file (option -a/--arbiter)"
         sys.exit(2)
 
     # Protect for windows multiprocessing that will RELAUNCH all
@@ -76,7 +76,6 @@ def main():
         if not daemon.need_config_reload:
             break
         daemon = None
-
 
 if __name__ == '__main__':
     main()

--- a/alignak/brok.py
+++ b/alignak/brok.py
@@ -58,6 +58,24 @@ from alignak.misc.serialization import serialize, unserialize, AlignakClassLooku
 class Brok(object):
     """A Brok is a piece of information exported by Alignak to the Broker.
     Broker can do whatever he wants with it.
+
+    Broks types:
+    - log
+    - monitoring_log
+
+    - notification_raise
+    - downtime_raise
+    - initial_host_status, initial_service_status, initial_contact_status
+    - initial_broks_done
+
+    - update_host_status, update_service_status, initial_contact_status
+    - host_check_result, service_check_result
+    - host_next_schedule, service_next_scheduler
+    - host_snapshot, service_snapshot
+    - unknown_host_check_result, unknown_service_check_result
+
+    - program_status
+    - clean_all_my_instance_id
     """
     my_type = 'brok'
 

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -126,6 +126,7 @@ except ImportError, exp:  # Like in nt system
         """
         return []
 
+from alignak.log import logger, setup_logger, get_logger_fds
 from alignak.http.daemon import HTTPDaemon, InvalidWorkDir
 from alignak.stats import statsmgr
 from alignak.modulesmanager import ModulesManager
@@ -146,12 +147,11 @@ UMASK = 027
 
 
 class InvalidPidFile(Exception):
-    """Exception raise when a pid file is invalid"""
+    """Exception raised when a pid file is invalid"""
     pass
 
 
-DEFAULT_WORK_DIR = '/var/run/alignak/'
-DEFAULT_LIB_DIR = '/var/lib/alignak/'
+DEFAULT_WORK_DIR = './'
 
 
 class Daemon(object):  # pylint: disable=R0902
@@ -167,22 +167,50 @@ class Daemon(object):  # pylint: disable=R0902
         #  os.path.join( os.getcwd(), sys.argv[0] )
         #
         # as returned once the daemon is started.
-        'workdir':       PathProp(default=DEFAULT_WORK_DIR),
-        'host':          StringProp(default='0.0.0.0'),
-        'user':          StringProp(default=get_cur_user()),
-        'group':         StringProp(default=get_cur_group()),
-        'use_ssl':       BoolProp(default=False),
-        'server_key':     StringProp(default='etc/certs/server.key'),
-        'ca_cert':       StringProp(default='etc/certs/ca.pem'),
-        'server_cert':   StringProp(default='etc/certs/server.cert'),
-        'use_local_log': BoolProp(default=True),
-        'log_level':     LogLevelProp(default='WARNING'),
-        'hard_ssl_name_check':    BoolProp(default=False),
-        'idontcareaboutsecurity': BoolProp(default=False),
-        'daemon_enabled': BoolProp(default=True),
-        'spare':         BoolProp(default=False),
-        'max_queue_size': IntegerProp(default=0),
-        'daemon_thread_pool_size': IntegerProp(default=8),
+        'workdir':
+            PathProp(default=DEFAULT_WORK_DIR),
+        'host':
+            StringProp(default='0.0.0.0'),
+        'user':
+            StringProp(default=get_cur_user()),
+        'group':
+            StringProp(default=get_cur_group()),
+        'use_ssl':
+            BoolProp(default=False),
+        'server_key':
+            StringProp(default='etc/certs/server.key'),
+        'ca_cert':
+            StringProp(default='etc/certs/ca.pem'),
+        'server_cert':
+            StringProp(default='etc/certs/server.cert'),
+        'use_local_log':
+            BoolProp(default=True),
+        'human_timestamp_log':
+            BoolProp(default=True),
+        'human_date_format':
+            StringProp(default='%Y-%m-%d %H:%M:%S %Z'),
+        'log_level':
+            LogLevelProp(default='INFO'),
+        'log_rotation_when':
+            StringProp(default='midnight'),
+        'log_rotation_interval':
+            IntegerProp(default=1),
+        'log_rotation_count':
+            IntegerProp(default=7),
+        'local_log':
+            StringProp(default='/usr/local/var/log/arbiter.log'),
+        'hard_ssl_name_check':
+            BoolProp(default=False),
+        'idontcareaboutsecurity':
+            BoolProp(default=False),
+        'daemon_enabled':
+            BoolProp(default=True),
+        'spare':
+            BoolProp(default=False),
+        'max_queue_size':
+            IntegerProp(default=0),
+        'daemon_thread_pool_size':
+            IntegerProp(default=8),
     }
 
     def __init__(self, name, config_file, is_daemon, do_replace, debug, debug_file):
@@ -198,6 +226,12 @@ class Daemon(object):  # pylint: disable=R0902
         self.interrupted = False
         self.pidfile = None
 
+        if self.debug:
+            print("Daemon %s is in debug mode" % self.name)
+
+        if self.is_daemon:
+            print("Daemon %s is in daemon mode" % self.name)
+
         # Track time
         now = time.time()
         self.program_start = now
@@ -207,13 +241,7 @@ class Daemon(object):  # pylint: disable=R0902
         self.http_thread = None
         self.http_daemon = None
 
-        # Log init
-        # self.log = logger
-        # self.log.load_obj(self)
-        # pylint: disable=E1101
-        logger.load_obj(self)
-
-        self.new_conf = None  # used by controller to push conf
+        self.new_conf = None
         self.cur_conf = None
         self.conf_lock = threading.RLock()
         self.lock = threading.RLock()
@@ -227,8 +255,8 @@ class Daemon(object):  # pylint: disable=R0902
         # Flag to reload configuration
         self.need_config_reload = False
 
-        # Keep a trace of the local_log file desc if needed
-        self.local_log_fd = None
+        # Keep a trace of the file descriptors allocated by the logger
+        self.local_log_fds = None
 
         # Put in queue some debug output we will raise
         # when we will be in daemon
@@ -241,6 +269,11 @@ class Daemon(object):  # pylint: disable=R0902
         os.umask(UMASK)
         self.set_exit_handler()
 
+        # Fill the properties
+        properties = self.__class__.properties
+        for prop, entry in properties.items():
+            setattr(self, prop, entry.pythonize(entry.default))
+
     # At least, lose the local log file if needed
     def do_stop(self):
         """Execute the stop of this daemon:
@@ -251,14 +284,14 @@ class Daemon(object):  # pylint: disable=R0902
 
         :return: None
         """
-        logger.info("%s : Doing stop ..", self)
+        logger.info("Stopping %s...", self.name)
 
         if self.http_daemon:
-            logger.info("Shutting down http_daemon ..")
+            logger.info("Shutting down http_daemon...")
             self.http_daemon.request_stop()
 
         if self.http_thread:
-            logger.info("Joining http_thread ..")
+            logger.info("Joining http_thread...")
             # Add a timeout to join so that we can manually quit
             self.http_thread.join(timeout=15)
             if self.http_thread.is_alive():
@@ -273,7 +306,7 @@ class Daemon(object):  # pylint: disable=R0902
             self.http_daemon = None
 
         if self.manager:
-            logger.info("Shutting down manager ..")
+            logger.info("Shutting down manager...")
             self.manager.shutdown()
             self.manager = None
 
@@ -285,10 +318,8 @@ class Daemon(object):  # pylint: disable=R0902
             if not hasattr(self, 'sched'):
                 self.hook_point('save_retention')
             # And we quit
-            logger.info('Stopping all modules')
+            logger.info('Stopping all modules...')
             self.modules_manager.stop_all()
-
-        logger.info("%s : All stop done.", self)
 
     def request_stop(self):
         """Remove pid and stop daemon
@@ -297,8 +328,8 @@ class Daemon(object):  # pylint: disable=R0902
         """
         self.unlink()
         self.do_stop()
-        # Brok facilities are no longer available simply print the message to STDOUT
-        print("Stopping daemon. Exiting")
+
+        logger.info("Stopped %s.", self.name)
         sys.exit(0)
 
     def look_for_early_exit(self):
@@ -327,12 +358,14 @@ class Daemon(object):  # pylint: disable=R0902
             self.do_loop_turn()
             # If ask us to dump memory, do it
             if self.need_dump_memory:
+                logger.debug('Dumping memory')
                 self.dump_memory()
                 self.need_dump_memory = False
             if self.need_objects_dump:
                 logger.debug('Dumping objects')
                 self.need_objects_dump = False
             if self.need_config_reload:
+                logger.debug('Ask for configuration reloading')
                 return
             # Maybe we ask us to die, if so, do it :)
             if self.interrupted:
@@ -344,9 +377,14 @@ class Daemon(object):  # pylint: disable=R0902
 
         :return: None
         """
+        logger.info("Loading modules...")
+
         self.modules_manager.load_and_init(mod_confs)
-        logger.info("I correctly loaded the modules: [%s]",
-                    ','.join([inst.get_name() for inst in self.modules_manager.instances]))
+        if self.modules_manager.instances:
+            logger.info("I correctly loaded my modules: [%s]",
+                        ','.join([inst.get_name() for inst in self.modules_manager.instances]))
+        else:
+            logger.info("I do not have any module")
 
     def add(self, elt):
         """ Abstract method for adding brok
@@ -366,7 +404,7 @@ class Daemon(object):  # pylint: disable=R0902
         :return: None
         TODO: Clean this
         """
-        logger.info("I dump my memory, it can take a minute")
+        logger.info("I dump my memory, it can take a while")
         try:
             from guppy import hpy
             heap = hpy()
@@ -377,8 +415,12 @@ class Daemon(object):  # pylint: disable=R0902
     def load_config_file(self):
         """Parse config file and ensure full path in variables
 
+        Note: do not use logger into this function because it is not yet initialized ;)
+
         :return: None
         """
+        print("Loading daemon configuration file (%s)..." % self.config_file)
+
         self.parse_config_file()
         if self.config_file is not None:
             # Some paths can be relatives. We must have a full path by taking
@@ -398,12 +440,14 @@ class Daemon(object):  # pylint: disable=R0902
 
         :return: None
         """
+        logger.info("Changing working directory to: %s", self.workdir)
         self.workdir = os.path.abspath(self.workdir)
         try:
             os.chdir(self.workdir)
         except Exception, exp:
             raise InvalidWorkDir(exp)
         self.debug_output.append("Successfully changed to workdir: %s" % (self.workdir))
+        logger.info("Using working directory: %s", os.path.abspath(self.workdir))
 
     def unlink(self):
         """Remove the daemon's pid file
@@ -415,21 +459,6 @@ class Daemon(object):  # pylint: disable=R0902
             os.unlink(self.pidfile)
         except OSError, exp:
             logger.error("Got an error unlinking our pidfile: %s", exp)
-
-    def register_local_log(self):
-        """Open local log file for logging purpose
-
-        :return: None
-        """
-        # The arbiter doesn't have such attribute
-        if hasattr(self, 'use_local_log') and self.use_local_log:
-            try:
-                # self.local_log_fd = self.log.register_local_log(self.local_log)
-                self.local_log_fd = logger.register_local_log(self.local_log)
-            except IOError, exp:
-                logger.error("Opening the log file '%s' failed with '%s'", self.local_log, exp)
-                sys.exit(2)
-            logger.info("Using the local log file '%s'", self.local_log)
 
     @staticmethod
     def check_shm():
@@ -476,7 +505,7 @@ class Daemon(object):  # pylint: disable=R0902
         """
         # TODO: other daemon run on nt
         if os.name == 'nt':
-            logger.warning("The parallel daemon check is not available on nt")
+            logger.warning("The parallel daemon check is not available on Windows")
             self.__open_pidfile(write=True)
             return
 
@@ -551,6 +580,7 @@ class Daemon(object):  # pylint: disable=R0902
         # Iterate through and close all file descriptors.
         for file_d in range(0, maxfd):
             if file_d in skip_close_fds:
+                logger.debug("Do not close fd: %s", file_d)
                 continue
             try:
                 os.close(file_d)
@@ -566,6 +596,8 @@ class Daemon(object):  # pylint: disable=R0902
         :type skip_close_fds: list
         :return: None
         """
+        logger.info("Daemonizing...")
+
         if skip_close_fds is None:
             skip_close_fds = tuple()
 
@@ -576,7 +608,7 @@ class Daemon(object):  # pylint: disable=R0902
             fdtemp = os.open(REDIRECT_TO, os.O_RDWR)
 
         # We close all fd but what we need:
-        self.close_fds(skip_close_fds + (self.fpid.fileno(), fdtemp))
+        self.close_fds(skip_close_fds + [self.fpid.fileno(), fdtemp])
 
         os.dup2(fdtemp, 1)  # standard output (1)
         os.dup2(fdtemp, 2)  # standard error (2)
@@ -660,28 +692,29 @@ class Daemon(object):  # pylint: disable=R0902
         self.check_parallel_run()
         self.setup_communication_daemon()
 
-        # Then start to log all in the local file if asked so
-        self.register_local_log()
         if self.is_daemon:
             # Do not close the local_log file too if it's open
-            if self.local_log_fd:
-                self.daemonize(skip_close_fds=(self.local_log_fd,))
+            if self.local_log_fds:
+                self.daemonize(skip_close_fds=self.local_log_fds)
+            else:
+                self.daemonize()
         else:
             self.write_pid()
 
-        logger.info("Creating manager ..")
+        logger.info("Creating manager...")
         self.manager = self._create_manager()
-        logger.info("done.")
+        logger.info("Created")
 
         # We can start our stats thread but after the double fork() call and if we are not in
         # a test launch (time.time() is hooked and will do BIG problems there)
         if not fake:
             statsmgr.launch_reaper_thread()
 
-        logger.info("Now starting http_daemon thread..")
+        logger.info("Starting HTTP daemon thread...")
         self.http_thread = threading.Thread(None, self.http_daemon_thread, 'http_thread')
         self.http_thread.daemon = True
         self.http_thread.start()
+        logger.info("HTTP daemon thread started")
 
     def setup_communication_daemon(self):
         """ Setup HTTP server daemon to listen
@@ -843,6 +876,8 @@ class Daemon(object):  # pylint: disable=R0902
         If some properties need a pythonization, we do it.
         Also put default value in the properties if some are missing in the config_file
 
+        TODO: @mohierf: why not doing this directly in load_config_file?
+
         :return: None
         """
         properties = self.__class__.properties
@@ -857,14 +892,15 @@ class Daemon(object):  # pylint: disable=R0902
                     if key in properties:
                         value = properties[key].pythonize(value)
                     setattr(self, key, value)
-            except ConfigParser.InterpolationMissingOptionError, err:
+            except ConfigParser.InterpolationMissingOptionError as err:
                 err = str(err)
                 wrong_variable = err.split('\n')[3].split(':')[1].strip()
                 logger.error("Incorrect or missing variable '%s' in config file : %s",
                              wrong_variable, self.config_file)
                 sys.exit(2)
         else:
-            logger.warning("No config file specified, use defaults parameters")
+            print("No daemon configuration file specified, using defaults parameters")
+
         # Now fill all defaults where missing parameters
         for prop, entry in properties.items():
             if not hasattr(self, prop):
@@ -872,8 +908,11 @@ class Daemon(object):  # pylint: disable=R0902
                 setattr(self, prop, value)
 
     def relative_paths_to_full(self, reference_path):
-        """Set a full path from a relative one with che config file as reference
+        """Set a full path from a relative one with the config file as reference
         TODO: This should be done in pythonize method of Properties.
+        TODO: @mohierf: why not doing this directly in load_config_file?
+        TODO: No property defined for the daemons is a ConfigPathProp ... ;)
+        This function is completely unuseful as is !!!
 
         :param reference_path: reference path for reading full path
         :type reference_path: str
@@ -886,10 +925,8 @@ class Daemon(object):  # pylint: disable=R0902
                 path = getattr(self, prop)
                 if not os.path.isabs(path):
                     new_path = os.path.join(reference_path, path)
-                    # print "DBG: changing", entry, "from", path, "to", new_path
                     path = new_path
                 setattr(self, prop, path)
-                # print "Setting %s for %s" % (path, prop)
 
     def manage_signal(self, sig, frame):  # pylint: disable=W0613
         """Manage signals caught by the daemon
@@ -940,23 +977,25 @@ class Daemon(object):  # pylint: disable=R0902
         setproctitle("alignak-%s" % self.name)
 
     @staticmethod
-    def get_header():
+    def get_header(daemon_name):
         """Get the log file header
 
-        :return: A string list containing project name, version, licence etc.
+        :param daemon_name: the daemon name to include in the header
+        :return: A string list containing project name, daemon name, version, licence etc.
         :rtype: list
         """
-        return ["Alignak %s" % VERSION,
-                "Copyright (c) 2015-2015:",
+        return ["Alignak %s - %s daemon" % (VERSION, daemon_name),
+                "Copyright (c) 2015-2016:",
                 "Alignak Team",
-                "License: AGPL"]
+                "License: AGPL",
+                "-----"]
 
     def print_header(self):
         """Log headers generated in get_header()
 
         :return: None
         """
-        for line in self.get_header():
+        for line in self.get_header(self.name):
             logger.info(line)
 
     def http_daemon_thread(self):
@@ -964,7 +1003,7 @@ class Daemon(object):  # pylint: disable=R0902
 
         :return: None
         """
-        logger.info("HTTP main thread: I'm running")
+        logger.info("HTTP main thread running")
         # The main thing is to have a pool of X concurrent requests for the http_daemon,
         # so "no_lock" calls can always be directly answer without having a "locked" version to
         # finish
@@ -973,6 +1012,7 @@ class Daemon(object):  # pylint: disable=R0902
         except Exception, exp:  # pylint: disable=W0703
             logger.exception('The HTTP daemon failed with the error %s, exiting', str(exp))
             raise exp
+        logger.info("HTTP main thread running")
 
     def handle_requests(self, timeout, suppl_socks=None):
         """ Wait up to timeout to handle the requests.
@@ -1126,8 +1166,12 @@ class Daemon(object):  # pylint: disable=R0902
         :rtype: dict
 
         """
-        res = {'metrics': [], 'version': VERSION, 'name': '', 'type': '', 'modules':
-               {'internal': {}, 'external': {}}}
+        res = {
+            'metrics': [], 'version': VERSION, 'name': self.name, 'type': '',
+            'modules': {
+                'internal': {}, 'external': {}
+            }
+        }
         modules = res['modules']
 
         # first get data for all internal modules
@@ -1155,8 +1199,9 @@ class Daemon(object):  # pylint: disable=R0902
         """
         logger.critical("I got an unrecoverable error. I have to exit.")
         logger.critical("You can get help at https://github.com/Alignak-monitoring/alignak")
-        logger.critical("If you think this is a bug, create a new ticket including"
+        logger.critical("If you think this is a bug, create a new ticket including "
                         "details mentioned in the README")
+        logger.critical("-----")
         logger.critical("Back trace of the error: %s", trace)
 
     def get_objects_from_from_queues(self):
@@ -1180,24 +1225,50 @@ class Daemon(object):  # pylint: disable=R0902
         return had_some_objects
 
     def setup_alignak_logger(self):
-        """ Setup alignak logger.
-        - Set log level
-        - Log Alignak headers
-        - Load config file
+        """ Setup alignak logger:
+        - load the daemon configuration file
+        - configure the global daemon handler (root logger)
+        - log the daemon Alignak header
+        - log the damon configuration parameters
 
         :return:
         :rtype:
         """
-        # Setting log level
-        alignak_logger = logging.getLogger("alignak")
-        alignak_logger.setLevel('INFO')
-        # Force the debug level if the daemon is said to start with such level
-        if self.debug:
-            alignak_logger.setLevel('DEBUG')
-
-        # Log will be broks
-        for line in self.get_header():
-            logger.info(line)
-
+        # Load the daemon configuration file
         self.load_config_file()
-        alignak_logger.setLevel(self.log_level)
+
+        # Force the debug level if the daemon is said to start with such level
+        log_level = self.log_level
+        if self.debug:
+            log_level = 'DEBUG'
+
+        # Set the human timestamp log if required
+        human_log_format = getattr(self, 'human_timestamp_log', False)
+
+        # Register local log file if required
+        if getattr(self, 'use_local_log', False):
+            try:
+                # pylint: disable=E1101
+                setup_logger(None, level=log_level, human_log=human_log_format,
+                             log_console=True, log_file=self.local_log,
+                             when=self.log_rotation_when, interval=self.log_rotation_interval,
+                             backup_count=self.log_rotation_count,
+                             human_date_format=self.human_date_format)
+            except IOError, exp:
+                logger.error("Opening the log file '%s' failed with '%s'", self.local_log, exp)
+                sys.exit(2)
+            logger.debug("Using the local log file '%s'", self.local_log)
+            self.local_log_fds = get_logger_fds(None)
+        else:
+            setup_logger(None, level=log_level, human_log=human_log_format,
+                         log_console=True, log_file=None)
+            logger.warning("No local log file")
+
+        logger.debug("Alignak daemon logger configured")
+
+        # Log daemon header
+        self.print_header()
+
+        logger.info("My configuration: ")
+        for prop, _ in self.properties.items():
+            logger.info(" - %s=%s", prop, getattr(self, prop, 'Not found!'))

--- a/alignak/daemons/brokerdaemon.py
+++ b/alignak/daemons/brokerdaemon.py
@@ -467,9 +467,7 @@ class Broker(BaseSatellite):
             self.statsd_prefix = g_conf['statsd_prefix']
             self.statsd_enabled = g_conf['statsd_enabled']
 
-            # We got a name so we can update the logger and the stats global objects
-            # pylint: disable=E1101
-            logger.load_obj(self, name)
+            # We got a name so we can update the stats global objects
             statsmgr.register(self, name, 'broker',
                               api_key=self.api_key, secret=self.secret, http_proxy=self.http_proxy,
                               statsd_host=self.statsd_host, statsd_port=self.statsd_port,
@@ -857,22 +855,22 @@ class Broker(BaseSatellite):
         try:
             self.setup_alignak_logger()
 
-            logger.info("[Broker] Using working directory: %s", os.path.abspath(self.workdir))
-
             # Look if we are enabled or not. If ok, start the daemon mode
             self.look_for_early_exit()
+
+            logger.info("[Broker] Using working directory: %s", os.path.abspath(self.workdir))
+
             self.do_daemon_init_and_start()
+
             self.load_modules_manager()
 
             #  We wait for initial conf
             self.wait_for_initial_conf()
             if not self.new_conf:
                 return
-
             self.setup_new_conf()
 
-            # Do the modules part, we have our modules in self.modules
-            # REF: doc/broker-modules.png (1)
+            # Restore retention data
             self.hook_point('load_retention')
 
             # Now the main loop

--- a/alignak/daemons/receiverdaemon.py
+++ b/alignak/daemons/receiverdaemon.py
@@ -217,12 +217,12 @@ class Receiver(Satellite):
             self.statsd_prefix = conf['global']['statsd_prefix']
             self.statsd_enabled = conf['global']['statsd_enabled']
 
+            # We got a name so we can update the stats global objects
             statsmgr.register(self, self.name, 'receiver',
                               api_key=self.api_key, secret=self.secret, http_proxy=self.http_proxy,
                               statsd_host=self.statsd_host, statsd_port=self.statsd_port,
                               statsd_prefix=self.statsd_prefix, statsd_enabled=self.statsd_enabled)
-            # pylint: disable=E1101
-            logger.load_obj(self, name)
+
             self.direct_routing = conf['global']['direct_routing']
             self.accept_passive_unknown_check_results = \
                 conf['global']['accept_passive_unknown_check_results']
@@ -396,8 +396,6 @@ class Receiver(Satellite):
             # Look if we are enabled or not. If ok, start the daemon mode
             self.look_for_early_exit()
 
-            logger.info("[Receiver] Using working directory: %s", os.path.abspath(self.workdir))
-
             self.do_daemon_init_and_start()
 
             self.load_modules_manager()
@@ -406,11 +404,7 @@ class Receiver(Satellite):
             self.wait_for_initial_conf()
             if not self.new_conf:
                 return
-
             self.setup_new_conf()
-
-            # Do the modules part, we have our modules in self.modules
-            # REF: doc/receiver-modules.png (1)
 
             # Now the main loop
             self.do_mainloop()

--- a/alignak/daemons/schedulerdaemon.py
+++ b/alignak/daemons/schedulerdaemon.py
@@ -260,11 +260,6 @@ class Alignak(BaseSatellite):
             self.override_conf = override_conf
             self.modules = unserialize(modules, True)
             self.satellites = satellites
-            # self.pollers = self.app.pollers
-
-            if self.conf.human_timestamp_log:
-                # pylint: disable=E1101
-                logger.set_human_format()
 
             # Now We create our pollers and reactionners
             for sat_type in ['pollers', 'reactionners']:
@@ -287,6 +282,7 @@ class Alignak(BaseSatellite):
                     sats[sat_id]['uri'] = uri
                     sats[sat_id]['last_connection'] = 0
                     setattr(self, sat_type, sats)
+                logger.info("We have our %s: %s ", sat_type, satellites[sat_type])
 
             # First mix conf and override_conf to have our definitive conf
             for prop in self.override_conf:
@@ -333,7 +329,7 @@ class Alignak(BaseSatellite):
             # activate it if necessary
             self.sched.load_external_command(ecm)
 
-            # External command need the sched because he can raise checks
+            # External command needs the sched because it can raise checks and broks
             ecm.load_scheduler(self.sched)
 
             # We clear our schedulers managed (it's us :) )
@@ -363,12 +359,17 @@ class Alignak(BaseSatellite):
         """
         try:
             self.setup_alignak_logger()
+
+            # Look if we are enabled or not. If ok, start the daemon mode
             self.look_for_early_exit()
+
             self.do_daemon_init_and_start()
+
             self.load_modules_manager()
 
             self.uri = self.http_daemon.uri
-            logger.info("[scheduler] General interface is at: %s", self.uri)
+            logger.info("[Scheduler] General interface is at: %s", self.uri)
+
             self.do_mainloop()
         except Exception:
             self.print_unrecoverable(traceback.format_exc())

--- a/alignak/log.py
+++ b/alignak/log.py
@@ -17,88 +17,42 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# This file incorporates work covered by the following copyright and
-# permission notice:
-#
-#  Copyright (C) 2009-2014:
-#     Hartmut Goebel, h.goebel@goebel-consult.de
-#     Guillaume Bour, guillaume@bour.cc
-#     xkilian, fmikus@acktomic.com
-#     Nicolas Dupeux, nicolas@dupeux.net
-#     Zoran Zaric, zz@zoranzaric.de
-#     Jan Ulferts, jan.ulferts@xing.com
-#     Grégory Starck, g.starck@gmail.com
-#     Frédéric Pégé, frederic.pege@gmail.com
-#     Sebastien Coavoux, s.coavoux@free.fr
-#     Thibault Cohen, titilambert@gmail.com
-#     Jean Gabes, naparuba@gmail.com
-#     Olivier Hanesse, olivier.hanesse@gmail.com
-#     Gerhard Lausser, gerhard.lausser@consol.de
-
-#  This file is part of Shinken.
-#
-#  Shinken is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU Affero General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  Shinken is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU Affero General Public License for more details.
-#
-#  You should have received a copy of the GNU Affero General Public License
-#  along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 """
-This module provide logging facilities for Alignak.
-There is a custom log handler that create broks for every log emitted with level < debug
+This module provides logging facilities for Alignak.
 """
-import logging
-import sys
 import os
-import stat
-from logging import Handler, Formatter, StreamHandler, NOTSET, FileHandler  # pylint: disable=C0412
-from logging.handlers import TimedRotatingFileHandler  # pylint: disable=C0412
+import sys
+
+import logging
+from logging import Formatter, StreamHandler
+from logging.handlers import TimedRotatingFileHandler
 
 from termcolor import cprint
 
+from alignak.brok import Brok
 
-# obj = None
-# name = None
-HUMAN_TIMESTAMP_LOG = False
+# Default values for root logger
+ROOT_LOGGER_NAME = 'alignak'
+ROOT_LOGGER_LEVEL = logging.INFO
 
-DEFAULT_FORMATTER = Formatter('[%(created)i] %(levelname)s: %(message)s')
+# Default ISO8601 UTC date formatting:
+HUMAN_DATE_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
+
+# Default log formatter (no human timestamp)
 DEFAULT_FORMATTER_NAMED = Formatter('[%(created)i] %(levelname)s: [%(name)s] %(message)s')
-HUMAN_FORMATTER = Formatter('[%(asctime)s] %(levelname)s: %(message)s', '%a %b %d %H:%M:%S %Y')
+
+# Human timestamped log formatter
 HUMAN_FORMATTER_NAMED = Formatter('[%(asctime)s] %(levelname)s: [%(name)s] %(message)s',
-                                  '%a %b %d %H:%M:%S %Y')
-NAG_FORMATTER = Formatter('[%(created)i] %(message)s')
+                                  HUMAN_DATE_FORMAT)
+
+# Time rotation for file logger
+ROTATION_WHEN = 'midnight'
+ROTATION_INTERVAL = 1
+ROTATION_COUNT = 5
 
 
-class BrokHandler(Handler):
-    """
-    This log handler is forwarding log messages as broks to the broker.
-
-    Only messages of level higher than DEBUG are send to other
-    satellite to not risk overloading them.
-    """
-
-    def __init__(self, broker):
-        # Only messages of level INFO or higher are passed on to the
-        # broker. Other handlers have a different level.
-        Handler.__init__(self, logging.INFO)
-        self._broker = broker
-
-    def emit(self, record):
-        try:
-            msg = self.format(record)
-            # Needed otherwise import loop (log -> brok -> serialization)
-            from alignak.brok import Brok
-            brok = Brok({'type': 'log', 'data': {'log': msg + '\n'}})
-            self._broker.add(brok)
-        except TypeError:
-            self.handleError(record)
+logger = logging.getLogger(ROOT_LOGGER_NAME)  # pylint: disable=C0103
+logger.setLevel(ROOT_LOGGER_LEVEL)
 
 
 class ColorStreamHandler(StreamHandler):
@@ -117,205 +71,97 @@ class ColorStreamHandler(StreamHandler):
             self.handleError(record)
 
 
-class Log(logging.Logger):
+def setup_logger(logger_, level=logging.INFO, log_file=None, log_console=True,
+                 when=ROTATION_WHEN, interval=ROTATION_INTERVAL, backup_count=ROTATION_COUNT,
+                 human_log=False, human_date_format=HUMAN_DATE_FORMAT):
     """
-    Alignak logger class, wrapping access to Python logging standard library.
-    See : https://docs.python.org/2/howto/logging.html#logging-flow for more detail about
-    how log are handled"""
+    Configure the provided logger
+    - appends a ColorStreamHandler if it is not yet present
+    - manages the formatter according to the required timestamp
+    - appends a TimedRotatingFileHandler if it is not yet present for the same file
+    - update level and formatter for already existing handlers
 
-    def __init__(self, name="Alignak", level=NOTSET, log_set=False):
-        logging.Logger.__init__(self, name, level)
-        self.pre_log_buffer = []
-        self.log_set = log_set
+    :param logger_: logger object to configure. If None, configure the root logger
+    :param level: log level
+    :param log_file:
+    :param log_console: True to configure the console stream handler
+    :param human_log: use a human readeable date format
+    :param when:
+    :param interval:
+    :param backup_count:
+    :param human_date_format
+    :return: the modified logger object
+    """
+    if logger_ is None:
+        logger_ = logging.getLogger(ROOT_LOGGER_NAME)
 
-    def setLevel(self, level):
-        """ Set level of logger and handlers.
-        The logger need the lowest level (see link above)
-
-        :param level: logger/handler level
-        :type level: int
-        :return: None
-        """
+    # Set logger level
+    if level is not None:
         if not isinstance(level, int):
             level = getattr(logging, level, None)
-            if not level or not isinstance(level, int):
-                raise TypeError('log level must be an integer')
-        # Not very useful, all we have to do is no to set the level > info for the brok handler
-        self.level = min(level, logging.INFO)
-        # Only set level to file and/or console handler
-        for handler in self.handlers:
-            if isinstance(handler, BrokHandler):
-                continue
-            handler.setLevel(level)
+        logger_.setLevel(level)
 
-    def load_obj(self, obj, name_=None):
-        """ We load the object where we will put log broks
-        with the 'add' method
+    formatter = DEFAULT_FORMATTER_NAMED
+    if human_log:
+        formatter = Formatter('[%(asctime)s] %(levelname)s: [%(name)s] %(message)s',
+                              human_date_format)
 
-        :param obj: object instance
-        :type obj: object
-        :param name_: name of object
-        :type name_: str | None
-        :return: None
-        """
-        __brokhandler__ = BrokHandler(obj)
-        if name_ is not None or self.name is not None:
-            if name_ is not None:
-                self.name = name_
-            # We need to se the name format to all other handlers
-            for handler in self.handlers:
-                handler.setFormatter(DEFAULT_FORMATTER_NAMED)
-            __brokhandler__.setFormatter(DEFAULT_FORMATTER_NAMED)
+    if log_console and hasattr(sys.stdout, 'isatty'):
+        for handler in logger_.handlers:
+            if isinstance(handler, ColorStreamHandler):
+                if handler.level != level:
+                    handler.setLevel(level)
+                handler.setFormatter(formatter)
+                break
         else:
-            __brokhandler__.setFormatter(DEFAULT_FORMATTER)
-        self.addHandler(__brokhandler__)
+            csh = ColorStreamHandler(sys.stdout)
+            csh.setFormatter(formatter)
+            logger_.addHandler(csh)
 
-    def register_local_log(self, path, level=None, purge_buffer=True):
-        """The alignak logging wrapper can write to a local file if needed
-        and return the file descriptor so we can avoid to
-        close it.
-
-        Add logging to a local log-file.
-
-        The file will be rotated once a day
-
-        :param path: path of log
-        :type path: str
-        :param level: level of log
-        :type level: None | int
-        :param purge_buffer: True if want purge the buffer, otherwise False
-        :type purge_buffer: bool
-        :return:
-        """
-        self.log_set = True
-        # Todo : Create a config var for backup count
-        if os.path.exists(path) and not stat.S_ISREG(os.stat(path).st_mode):
-            # We don't have a regular file here. Rotate may fail
-            # It can be one of the stat.S_IS* (FIFO? CHR?)
-            handler = FileHandler(path)
+    if log_file:
+        for handler in logger_.handlers:
+            if isinstance(handler, TimedRotatingFileHandler) \
+                    and handler.baseFilename == os.path.abspath(log_file):
+                if handler.level != level:
+                    handler.setLevel(level)
+                handler.setFormatter(formatter)
+                break
         else:
-            handler = TimedRotatingFileHandler(path, 'midnight',  # pylint: disable=R0204
-                                               backupCount=5)
-        if level is not None:
-            handler.setLevel(level)
-        if self.name is not None:
-            handler.setFormatter(DEFAULT_FORMATTER_NAMED)
-        else:
-            handler.setFormatter(DEFAULT_FORMATTER)
-        self.addHandler(handler)
+            file_handler = TimedRotatingFileHandler(log_file,
+                                                    when=when, interval=interval,
+                                                    backupCount=backup_count)
+            file_handler.setFormatter(formatter)
+            logger_.addHandler(file_handler)
 
-        # Ok now unstack all previous logs
-        if purge_buffer:
-            self._destack()
-
-        # Todo : Do we need this now we use logging?
-        return handler.stream.fileno()
-
-    def set_human_format(self, human=True):
-        """
-        Set the output as human format.
-
-        If the optional parameter `human` is False, the timestamps format
-        will be reset to the default format.
-
-        :param human: True if want timestamp in human format, otherwise False
-        :type human: bool
-        :return: None
-        """
-        global HUMAN_TIMESTAMP_LOG  # pylint: disable=W0603
-        HUMAN_TIMESTAMP_LOG = bool(human)
-
-        # Apply/Remove the human format to all handlers except the brok one.
-        for handler in self.handlers:
-            if isinstance(handler, BrokHandler):
-                continue
-
-            if self.name is not None:
-                handler.setFormatter(HUMAN_TIMESTAMP_LOG and HUMAN_FORMATTER_NAMED or
-                                     DEFAULT_FORMATTER_NAMED)
-            else:
-                handler.setFormatter(HUMAN_TIMESTAMP_LOG and HUMAN_FORMATTER or DEFAULT_FORMATTER)
-
-    def _stack(self, level, args, kwargs):
-        """
-        Stack logs if we don't open a log file so we will be able to flush them
-        Stack max 500 logs (no memory leak please...)
-
-        :param level: level log
-        :type level: int
-        :param args: arguments
-        :type args:
-        :param kwargs:
-        :type kwargs:
-        :return: None
-        """
-        if self.log_set:
-            return
-        self.pre_log_buffer.append((level, args, kwargs))
-        if len(self.pre_log_buffer) > 500:
-            self.pre_log_buffer = self.pre_log_buffer[2:]
-
-    def _destack(self):
-        """
-        DIRTY HACK : log should be always written to a file.
-        we are opening a log file, flush all the logs now
-
-        :return: None
-        """
-        for (level, args, kwargs) in self.pre_log_buffer:
-            fun = getattr(logging.Logger, level, None)
-            if fun is None:
-                self.warning('Missing level for a log? %s', level)
-                continue
-            fun(self, *args, **kwargs)
-
-    def debug(self, *args, **kwargs):
-        self._stack('debug', args, kwargs)
-        logging.Logger.debug(self, *args, **kwargs)
-
-    def info(self, *args, **kwargs):
-        self._stack('info', args, kwargs)
-        # super(logging.Logger, self).info(*args, **kwargs)
-        logging.Logger.info(self, *args, **kwargs)
-
-    def warning(self, *args, **kwargs):
-        self._stack('warning', args, kwargs)
-        logging.Logger.warning(self, *args, **kwargs)
-
-    def error(self, *args, **kwargs):
-        self._stack('error', args, kwargs)
-        logging.Logger.error(self, *args, **kwargs)
+    return logger_
 
 
-# --- create the main logger ---
-logging.setLoggerClass(Log)
-# pylint: disable=C0103
-logger = logging.getLogger('alignak')  # pylint: disable=C0103
-if hasattr(sys.stdout, 'isatty'):
-    CSH = ColorStreamHandler(sys.stdout)
-    if logger.name is not None:
-        CSH.setFormatter(DEFAULT_FORMATTER_NAMED)
-    else:
-        CSH.setFormatter(DEFAULT_FORMATTER)
-    logger.addHandler(CSH)
-
-
-def naglog_result(level, result):
+def get_logger_fds(logger_):
     """
-    Function use for old Nag compatibility. We to set format properly for this call only.
+    Get the file descriptors used by the logger
 
-    Dirty Hack to keep the old format, we should have another logger and
-    use one for Alignak logs and another for monitoring data
+    :param logger_: logger object to configure. If None, configure the root logger
+    :return: list of file descriptors
     """
-    prev_formatters = []
-    for handler in logger.handlers:
-        prev_formatters.append(handler.formatter)
-        handler.setFormatter(NAG_FORMATTER)
+    if logger_ is None:
+        logger_ = logging.getLogger(ROOT_LOGGER_NAME)
 
-    log_fun = getattr(logger, level)
+    fds = []
+    for handler in logger_.handlers:
+        fds.append(handler.stream.fileno())
 
-    if log_fun:
-        log_fun(result)
+    return fds
 
-    for index, handler in enumerate(logger.handlers):
-        handler.setFormatter(prev_formatters[index])
+
+def make_monitoring_log(level, message):
+    """
+    Function used to build the monitoring log. Build a Brok typed as monitoring_log with
+    the message to log
+
+    TODO: replace with dedicated brok for each event to log
+
+    :param level: log level as defined in logging
+    :param message: message to insert into the monitoring log
+    :return:
+    """
+    return Brok({'type': 'monitoring_log', 'data': {'level': level, 'message': message}})

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -119,8 +119,7 @@ from alignak.objects.receiverlink import ReceiverLink, ReceiverLinks
 from alignak.objects.pollerlink import PollerLink, PollerLinks
 from alignak.graph import Graph
 from alignak.property import (UnusedProp, BoolProp, IntegerProp, CharProp,
-                              StringProp, LogLevelProp, ListProp, ToGuessProp)
-from alignak.daemon import get_cur_user, get_cur_group
+                              StringProp, ListProp, ToGuessProp)
 from alignak.util import jsonify_r
 
 
@@ -155,27 +154,18 @@ class Config(Item):  # pylint: disable=R0904,R0902
     #  in Alignak
     # *usage_text: if present, will print it to explain why it's no more useful
     properties = {
+        # Used for the PREFIX macro
+        # Alignak prefix does not axist as for Nagios meaning.
+        # It is better to set this value as an empty string rather than an meaningless information!
         'prefix':
-            StringProp(default='/usr/local/alignak/'),
+            StringProp(default=''),
 
-        'workdir':
-            StringProp(default='/var/run/alignak/'),
+        # Used for the MAINCONFIGFILE macro
+        'main_config_file':
+            StringProp(default='/usr/local/etc/alignak/alignak.cfg'),
 
         'config_base_dir':
             StringProp(default=''),  # will be set when we will load a file
-
-        'use_local_log':
-            BoolProp(default=True),
-
-        'log_level':
-            LogLevelProp(default='WARNING'),
-
-
-        'local_log':
-            StringProp(default='/var/log/alignak/arbiterd.log'),
-
-        'log_file':
-            UnusedProp(text=NO_LONGER_USED),
 
         'object_cache_file':
             UnusedProp(text=NO_LONGER_USED),
@@ -195,12 +185,6 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'status_update_interval':
             UnusedProp(text=NO_LONGER_USED),
 
-        'alignak_user':
-            StringProp(default=get_cur_user()),
-
-        'alignak_group':
-            StringProp(default=get_cur_group()),
-
         'enable_notifications':
             BoolProp(default=True, class_inherit=[(Host, None), (Service, None), (Contact, None)]),
 
@@ -219,11 +203,14 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'enable_event_handlers':
             BoolProp(default=True, class_inherit=[(Host, None), (Service, None)]),
 
+        # Inner simple log self created module parameter
         'log_rotation_method':
             CharProp(default='d'),
 
+        # Inner simple log self created module parameter
         'log_archive_path':
             StringProp(default='/usr/local/alignak/var/archives'),
+
         'check_external_commands':
             BoolProp(default=True),
 
@@ -245,13 +232,11 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'bare_update_checks':
             UnusedProp(text=None),
 
-        'lock_file':
-            StringProp(default='/var/run/alignak/arbiterd.pid'),
-
         'retain_state_information':
             UnusedProp(text='sorry, retain state information will not be implemented '
                             'because it is useless.'),
 
+        # Inner status.dat self created module parameters
         'state_retention_file':
             StringProp(default=''),
 
@@ -282,9 +267,11 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'retained_contact_service_attribute_mask':
             UnusedProp(text=NOT_INTERESTING),
 
+        # Inner syslog self created module parameters
         'use_syslog':
             BoolProp(default=False),
 
+        # Monitoring logs configuration
         'log_notifications':
             BoolProp(default=True, class_inherit=[(Host, None), (Service, None)]),
 
@@ -364,24 +351,28 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'use_aggressive_host_checking':
             BoolProp(default=False, class_inherit=[(Host, None)]),
 
+        # Todo: not used anywhere in the source code
         'translate_passive_host_checks':
             BoolProp(managed=False, default=True),
 
         'passive_host_checks_are_soft':
             BoolProp(managed=False, default=True),
 
+        # Todo: not used anywhere in the source code
         'enable_predictive_host_dependency_checks':
             BoolProp(managed=False,
                      default=True,
                      class_inherit=[(Host, 'enable_predictive_dependency_checks')]),
 
+        # Todo: not used anywhere in the source code
         'enable_predictive_service_dependency_checks':
             BoolProp(managed=False, default=True),
 
+        # Todo: not used anywhere in the source code
         'cached_host_check_horizon':
             IntegerProp(default=0, class_inherit=[(Host, 'cached_check_horizon')]),
 
-
+        # Todo: not used anywhere in the source code
         'cached_service_check_horizon':
             IntegerProp(default=0, class_inherit=[(Service, 'cached_check_horizon')]),
 
@@ -413,6 +404,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'high_host_flap_threshold':
             IntegerProp(default=30, class_inherit=[(Host, 'global_high_flap_threshold')]),
 
+        # Todo: not used anywhere in the source code
         'soft_state_dependencies':
             BoolProp(managed=False, default=False),
 
@@ -440,6 +432,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'perfdata_timeout':
             IntegerProp(default=5, class_inherit=[(Host, None), (Service, None)]),
 
+        # Todo: Is it still of any interest to keep this Nagios distributed feature?
         'obsess_over_services':
             BoolProp(default=False, class_inherit=[(Service, 'obsess_over')]),
 
@@ -461,6 +454,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'service_perfdata_command':
             StringProp(default='', class_inherit=[(Service, 'perfdata_command')]),
 
+        # Inner perfdata self created module parameters
         'host_perfdata_file':
             StringProp(default='', class_inherit=[(Host, 'perfdata_file')]),
 
@@ -494,9 +488,11 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'service_perfdata_file_processing_command':
             StringProp(managed=False, default=None),
 
+        # Todo: not used anywhere in the source code
         'check_for_orphaned_services':
             BoolProp(default=True, class_inherit=[(Service, 'check_for_orphaned')]),
 
+        # Todo: not used anywhere in the source code
         'check_for_orphaned_hosts':
             BoolProp(default=True, class_inherit=[(Host, 'check_for_orphaned')]),
 
@@ -523,6 +519,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'use_embedded_perl_implicitly':
             BoolProp(managed=False, default=False),
 
+        # Todo: not used anywhere in the source code
         'date_format':
             StringProp(managed=False, default=None),
 
@@ -572,14 +569,6 @@ class Config(Item):  # pylint: disable=R0904,R0902
 
         'modified_attributes':
             IntegerProp(default=0L),
-        # '$USERn$: {'required':False, 'default':''} # Add at run in __init__
-
-        # ALIGNAK SPECIFIC
-        'idontcareaboutsecurity':
-            BoolProp(default=False),
-
-        'daemon_enabled':
-            BoolProp(default=True),  # Put to 0 to disable the arbiter to run
 
         'daemon_thread_pool_size':
             IntegerProp(default=8),
@@ -609,29 +598,6 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'resource_macros_names':
             ListProp(default=[]),
 
-        # SSL PART
-        # global boolean for know if we use ssl or not
-        'use_ssl':
-            BoolProp(default=False,
-                     class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
-                                    (BrokerLink, None), (PollerLink, None),
-                                    (ReceiverLink, None), (ArbiterLink, None)]),
-        'ca_cert':
-            StringProp(default='etc/certs/ca.pem'),
-
-        'server_cert':
-            StringProp(default='etc/certs/server.cert'),
-
-        'server_key':
-            StringProp(default='etc/certs/server.key'),
-
-        'hard_ssl_name_check':
-            BoolProp(default=False),
-
-        # Log format
-        'human_timestamp_log':
-            BoolProp(default=False),
-
         'runners_timeout':
             IntegerProp(default=3600),
 
@@ -641,20 +607,11 @@ class Config(Item):  # pylint: disable=R0904,R0902
         'pack_distribution_file':
             StringProp(default='pack_distribution.dat'),
 
-        # WEBUI part
-        'webui_lock_file':
-            StringProp(default='webui.pid'),
-
-        'webui_port':
-            IntegerProp(default=8080),
-
-        'webui_host':
-            StringProp(default='0.0.0.0'),
-
-        # Large env tweacks
+        # Large env tweaks
         'use_multiprocesses_serializer':
             BoolProp(default=False),
 
+        # Todo: should remove this, as it is not used anymore...
         # About alignak.io part
         'api_key':
             StringProp(default='',
@@ -695,7 +652,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
 
     macros = {
         'PREFIX':               'prefix',
-        'MAINCONFIGFILE':       '',
+        'MAINCONFIGFILE':       'main_config_file',
         'STATUSDATAFILE':       '',
         'COMMENTDATAFILE':      '',
         'DOWNTIMEDATAFILE':     '',
@@ -976,6 +933,8 @@ class Config(Item):  # pylint: disable=R0904,R0902
                 buf = file_d.readlines()
                 file_d.close()
                 self.config_base_dir = os.path.dirname(c_file)
+                # Update macro used properties
+                self.main_config_file = os.path.abspath(c_file)
             except IOError, exp:
                 msg = "[config] cannot open main config file '%s' for reading: %s" % (c_file, exp)
                 self.add_error(msg)

--- a/alignak/objects/contact.py
+++ b/alignak/objects/contact.py
@@ -57,7 +57,7 @@ from alignak.objects.commandcallitem import CommandCallItems
 
 from alignak.util import strip_and_uniq
 from alignak.property import BoolProp, IntegerProp, StringProp, ListProp
-from alignak.log import naglog_result
+from alignak.log import make_monitoring_log
 from alignak.commandcall import CommandCall
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
@@ -319,8 +319,11 @@ class Contact(Item):
 
         :return: None
         """
-        naglog_result('info', "CONTACT DOWNTIME ALERT: %s;STARTED; Contact has "
-                      "entered a period of scheduled downtime" % self.get_name())
+        brok = make_monitoring_log(
+            'info', "CONTACT DOWNTIME ALERT: %s;STARTED; "
+                    "Contact has entered a period of scheduled downtime" % self.get_name()
+        )
+        self.broks.append(brok)
 
     def raise_exit_downtime_log_entry(self):
         """Raise CONTACT DOWNTIME ALERT entry (info level)
@@ -331,8 +334,11 @@ class Contact(Item):
 
         :return: None
         """
-        naglog_result('info', "CONTACT DOWNTIME ALERT: %s;STOPPED; Contact has "
-                      "exited from a period of scheduled downtime" % self.get_name())
+        brok = make_monitoring_log(
+            'info', "CONTACT DOWNTIME ALERT: %s;STOPPED; "
+                    "Contact has exited from a period of scheduled downtime" % self.get_name()
+        )
+        self.broks.append(brok)
 
     def raise_cancel_downtime_log_entry(self):
         """Raise CONTACT DOWNTIME ALERT entry (info level)
@@ -343,8 +349,11 @@ class Contact(Item):
 
         :return: None
         """
-        naglog_result('info', "CONTACT DOWNTIME ALERT: %s;CANCELLED; Scheduled "
-                      "downtime for contact has been cancelled." % self.get_name())
+        brok = make_monitoring_log(
+            'info', "CONTACT DOWNTIME ALERT: %s;CANCELLED; "
+                    "Scheduled downtime for contact has been cancelled." % self.get_name()
+        )
+        self.broks.append(brok)
 
 
 class Contacts(CommandCallItems):

--- a/alignak/objects/notificationway.py
+++ b/alignak/objects/notificationway.py
@@ -71,6 +71,8 @@ class NotificationWay(Item):
 
     properties = Item.properties.copy()
     properties.update({
+        'uuid':
+            StringProp(default='', fill_brok=['full_status']),
         'notificationway_name':
             StringProp(fill_brok=['full_status']),
         'host_notifications_enabled':

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -81,7 +81,7 @@ from alignak.util import (
     is_complex_expr,
     KeyValueSyntaxError)
 from alignak.property import BoolProp, IntegerProp, StringProp, ListProp, CharProp
-from alignak.log import naglog_result
+from alignak.log import make_monitoring_log
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
@@ -599,10 +599,14 @@ class Service(SchedulingItem):
 
         :return: None
         """
-        naglog_result('critical', 'SERVICE ALERT: %s;%s;%s;%s;%d;%s'
-                                  % (self.host_name, self.get_name(),
-                                     self.state, self.state_type,
-                                     self.attempt, self.output))
+        brok = make_monitoring_log(
+            'critical', 'SERVICE ALERT: %s;%s;%s;%s;%d;%s' % (
+                self.host_name, self.get_name(),
+                self.state, self.state_type,
+                self.attempt, self.output
+            )
+        )
+        self.broks.append(brok)
 
     def raise_initial_state(self):
         """Raise SERVICE HOST ALERT entry (info level)
@@ -613,9 +617,14 @@ class Service(SchedulingItem):
         :return: None
         """
         if self.__class__.log_initial_states:
-            naglog_result('info', 'CURRENT SERVICE STATE: %s;%s;%s;%s;%d;%s'
-                                  % (self.host_name, self.get_name(),
-                                     self.state, self.state_type, self.attempt, self.output))
+            brok = make_monitoring_log(
+                'info', 'CURRENT SERVICE STATE: %s;%s;%s;%s;%d;%s' % (
+                    self.host_name, self.get_name(),
+                    self.state, self.state_type,
+                    self.attempt, self.output
+                )
+            )
+            self.broks.append(brok)
 
     def raise_freshness_log_entry(self, t_stale_by, t_threshold):
         """Raise freshness alert entry (warning level)
@@ -656,10 +665,14 @@ class Service(SchedulingItem):
         else:
             state = self.state
         if self.__class__.log_notifications:
-            naglog_result('critical', "SERVICE NOTIFICATION: %s;%s;%s;%s;%s;%s"
-                                      % (contact.get_name(),
-                                         host_ref.get_name(), self.get_name(), state,
-                                         command.get_name(), self.output))
+            brok = make_monitoring_log(
+                'critical', "SERVICE NOTIFICATION: %s;%s;%s;%s;%s;%s" % (
+                    contact.get_name(),
+                    host_ref.get_name(), self.get_name(), state,
+                    command.get_name(), self.output
+                )
+            )
+            self.broks.append(brok)
 
     def raise_event_handler_log_entry(self, command):
         """Raise SERVICE EVENT HANDLER entry (critical level)
@@ -672,10 +685,14 @@ class Service(SchedulingItem):
         :return: None
         """
         if self.__class__.log_event_handlers:
-            naglog_result('critical', "SERVICE EVENT HANDLER: %s;%s;%s;%s;%s;%s"
-                                      % (self.host_name, self.get_name(),
-                                         self.state, self.state_type,
-                                         self.attempt, command.get_name()))
+            brok = make_monitoring_log(
+                'critical', "SERVICE EVENT HANDLER: %s;%s;%s;%s;%s;%s" % (
+                    self.host_name, self.get_name(),
+                    self.state, self.state_type,
+                    self.attempt, command.get_name()
+                )
+            )
+            self.broks.append(brok)
 
     def raise_snapshot_log_entry(self, command):
         """Raise SERVICE SNAPSHOT entry (critical level)
@@ -688,9 +705,14 @@ class Service(SchedulingItem):
         :return: None
         """
         if self.__class__.log_event_handlers:
-            naglog_result('critical', "SERVICE SNAPSHOT: %s;%s;%s;%s;%s;%s"
-                          % (self.host_name, self.get_name(),
-                             self.state, self.state_type, self.attempt, command.get_name()))
+            brok = make_monitoring_log(
+                'critical', "SERVICE SNAPSHOT: %s;%s;%s;%s;%s;%s" % (
+                    self.host_name, self.get_name(),
+                    self.state, self.state_type,
+                    self.attempt, command.get_name()
+                )
+            )
+            self.broks.append(brok)
 
     def raise_flapping_start_log_entry(self, change_ratio, threshold):
         """Raise SERVICE FLAPPING ALERT START entry (critical level)
@@ -705,11 +727,13 @@ class Service(SchedulingItem):
         :param threshold: threshold (percent) to trigger this log entry
         :return: None
         """
-        naglog_result('critical', "SERVICE FLAPPING ALERT: %s;%s;STARTED; "
-                                  "Service appears to have started flapping "
-                                  "(%.1f%% change >= %.1f%% threshold)"
-                                  % (self.host_name, self.get_name(),
-                                     change_ratio, threshold))
+        brok = make_monitoring_log(
+            'critical', "SERVICE FLAPPING ALERT: %s;%s;STARTED; "
+                        "Service appears to have started flapping "
+                        "(%.1f%% change >= %.1f%% threshold)" %
+                        (self.host_name, self.get_name(), change_ratio, threshold)
+        )
+        self.broks.append(brok)
 
     def raise_flapping_stop_log_entry(self, change_ratio, threshold):
         """Raise SERVICE FLAPPING ALERT STOPPED entry (critical level)
@@ -726,11 +750,13 @@ class Service(SchedulingItem):
         :type threshold: float
         :return: None
         """
-        naglog_result('critical', "SERVICE FLAPPING ALERT: %s;%s;STOPPED; "
-                                  "Service appears to have stopped flapping "
-                                  "(%.1f%% change < %.1f%% threshold)"
-                                  % (self.host_name, self.get_name(),
-                                     change_ratio, threshold))
+        brok = make_monitoring_log(
+            'critical', "SERVICE FLAPPING ALERT: %s;%s;STOPPED; "
+                        "Service appears to have stopped flapping "
+                        "(%.1f%% change < %.1f%% threshold)" %
+                        (self.host_name, self.get_name(), change_ratio, threshold)
+        )
+        self.broks.append(brok)
 
     def raise_no_next_check_log_entry(self):
         """Raise no scheduled check entry (warning level)
@@ -754,9 +780,12 @@ class Service(SchedulingItem):
 
         :return: None
         """
-        naglog_result('critical', "SERVICE DOWNTIME ALERT: %s;%s;STARTED; "
-                                  "Service has entered a period of scheduled "
-                                  "downtime" % (self.host_name, self.get_name()))
+        brok = make_monitoring_log(
+            'critical', "SERVICE DOWNTIME ALERT: %s;%s;STARTED; "
+                        "Service has entered a period of scheduled downtime" %
+                        (self.host_name, self.get_name())
+        )
+        self.broks.append(brok)
 
     def raise_exit_downtime_log_entry(self):
         """Raise SERVICE DOWNTIME ALERT entry (critical level)
@@ -767,9 +796,12 @@ class Service(SchedulingItem):
 
         :return: None
         """
-        naglog_result('critical', "SERVICE DOWNTIME ALERT: %s;%s;STOPPED; Service "
-                                  "has exited from a period of scheduled downtime"
-                      % (self.host_name, self.get_name()))
+        brok = make_monitoring_log(
+            'critical', "SERVICE DOWNTIME ALERT: %s;%s;STOPPED; Service "
+                        "has exited from a period of scheduled downtime" %
+                        (self.host_name, self.get_name())
+        )
+        self.broks.append(brok)
 
     def raise_cancel_downtime_log_entry(self):
         """Raise SERVICE DOWNTIME ALERT entry (critical level)
@@ -780,10 +812,12 @@ class Service(SchedulingItem):
 
         :return: None
         """
-        naglog_result(
+        brok = make_monitoring_log(
             'critical', "SERVICE DOWNTIME ALERT: %s;%s;CANCELLED; "
-                        "Scheduled downtime for service has been cancelled."
-            % (self.host_name, self.get_name()))
+                        "Scheduled downtime for service has been cancelled." %
+                        (self.host_name, self.get_name())
+        )
+        self.broks.append(brok)
 
     def manage_stalking(self, check):
         """Check if the service need stalking or not (immediate recheck)

--- a/alignak/objects/timeperiod.py
+++ b/alignak/objects/timeperiod.py
@@ -130,7 +130,7 @@ from alignak.daterange import StandardDaterange, MonthWeekDayDaterange
 from alignak.daterange import MonthDateDaterange, WeekDayDaterange
 from alignak.daterange import MonthDayDaterange
 from alignak.property import IntegerProp, StringProp, ListProp, BoolProp
-from alignak.log import naglog_result
+from alignak.log import make_monitoring_log
 from alignak.misc.serialization import get_alignak_class
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
@@ -340,7 +340,7 @@ class Timeperiod(Item):
         0: when timeperiod end
         1: when timeperiod start
 
-        :return: None
+        :return: None or a brok if TP changed
         """
         now = int(time.time())
 
@@ -361,10 +361,11 @@ class Timeperiod(Item):
                 _to = 1
 
             # Now raise the log
-            naglog_result(
-                'info', 'TIMEPERIOD TRANSITION: %s;%d;%d'
-                % (self.get_name(), _from, _to)
+            brok = make_monitoring_log(
+                'info', 'TIMEPERIOD TRANSITION: %s;%d;%d' % (self.get_name(), _from, _to)
             )
+            return brok
+        return None
 
     def clean_cache(self):
         """

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -169,10 +169,6 @@ class Scheduler(object):  # pylint: disable=R0902
             }
         }
 
-        # Log init
-        # pylint: disable=E1101
-        logger.load_obj(self)
-
         self.instance_id = 0  # Temporary set. Will be erase later
 
         # Ours queues
@@ -995,6 +991,10 @@ class Scheduler(object):  # pylint: disable=R0902
         :return: True if  now - last_connection < 5, False otherwise
         :rtype: bool
         """
+        # Never connected
+        if 'last_connection' not in elt:
+            return False
+
         now = time.time()
         last_connection = elt['last_connection']
         if now - last_connection < 5:
@@ -1014,7 +1014,7 @@ class Scheduler(object):  # pylint: disable=R0902
         # Get good links tab for looping..
         links = self.get_links_from_type(s_type)
         if links is None:
-            logger.debug("Unknown '%s' type for connection!", s_type)
+            logger.critical("Unknown '%s' type for connection!", s_type)
             return
 
         # We want only to initiate connections to the passive
@@ -1064,6 +1064,7 @@ class Scheduler(object):  # pylint: disable=R0902
         :return: None
         """
         # We loop for our passive pollers or reactionners
+        # Todo: only do this if there is some actions to push!
         for poll in self.pollers.values():
             if not poll['passive']:
                 continue
@@ -1092,6 +1093,7 @@ class Scheduler(object):  # pylint: disable=R0902
 
         # TODO:factorize
         # We loop for our passive reactionners
+        # Todo: only do this if there is some actions to push!
         for poll in self.reactionners.values():
             if not poll['passive']:
                 continue

--- a/alignak/util.py
+++ b/alignak/util.py
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=C0103
 try:
     SAFE_STDOUT = (sys.stdout.encoding == 'UTF-8')
 except AttributeError, exp:
-    logger.error('Encoding detection error= %s', exp)
+    logger.error('Encoding detection error for stdout = %s', exp)
     SAFE_STDOUT = False
 
 
@@ -1323,18 +1323,19 @@ def parse_daemon_args(arbiter=False):
     """
     parser = argparse.ArgumentParser(version="%(prog)s " + VERSION)
     if arbiter:
-        parser.add_argument('-c', '--config', action='append', dest="config_files",
-                            help='Configuration file(s),'
-                                 'multiple -c can be used, they will be concatenated')
+        parser.add_argument('-a', '--arbiter', action='append', required=True,
+                            dest="monitoring_files",
+                            help='Monitored configuration file(s),'
+                                 'multiple -a can be used, and they will be concatenated. ')
         parser.add_argument("-V", "--verify-config", dest="verify_only", action="store_true",
                             help="Verify config file and exit")
         parser.add_argument("-n", "--config-name", dest="config_name",
                             default='arbiter-master',
                             help="Use name of arbiter defined in the configuration files "
                                  "(default arbiter-master)")
-    else:
-        parser.add_argument('-c', '--config', dest="config_file", required=True,
-                            help='Config file')
+
+    parser.add_argument('-c', '--config', dest="config_file",
+                        help='Daemon configuration file')
     parser.add_argument('-d', '--daemon', dest="is_daemon", action='store_true',
                         help='Run as a daemon')
     parser.add_argument('-r', '--replace', dest="do_replace", action='store_true',

--- a/alignak/worker.py
+++ b/alignak/worker.py
@@ -60,7 +60,6 @@ import uuid
 import cStringIO
 import logging
 
-from alignak.log import BrokHandler
 from alignak.misc.common import setproctitle
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
@@ -111,10 +110,11 @@ class Worker(object):
     @staticmethod
     def _prework(real_work, *args):
         """Simply drop the BrokHandler before doing the real_work"""
-        for handler in list(logger.handlers):
-            if isinstance(handler, BrokHandler):
-                logger.info("Cleaning BrokHandler %r from logger.handlers..", handler)
-                logger.removeHandler(handler)
+        # # No more necessary thanks to the new logger
+        # for handler in list(logger.handlers):
+        #     if isinstance(handler, BrokHandler):
+        #         logger.info("Cleaning BrokHandler %r from logger.handlers..", handler)
+        #         logger.removeHandler(handler)
         real_work(*args)
 
     def is_mortal(self):

--- a/bin/default/alignak.in
+++ b/bin/default/alignak.in
@@ -60,6 +60,9 @@ LIB=$LIB$
 
 
 ### ARBITER PART ###
+# location of the arbiter daemon configuration
+ARBITERCFG="$ETC/daemons/arbiterd.ini"
+
 # location of the alignak configuration file
 # Please update $ETC$ instead of this one.
 ALIGNAKCFG="$ETC/alignak.cfg"

--- a/bin/init.d/alignak
+++ b/bin/init.d/alignak
@@ -270,17 +270,17 @@ do_start() {
     }
     [ "$DEBUG" = 1 ] && DEBUGCMD="--debug "$(getdebugfile "$mod")
     # Arbiter alignak.cfg, and the other OTHERd.ini
+    modINI=$(echo "$"${mod}CFG | tr '[:lower:]' '[:upper:]')
+    modinifile=$(eval echo ${modINI})
     if [ "$mod" != "arbiter" ]; then
-        modINI=$(echo "$"${mod}CFG | tr '[:lower:]' '[:upper:]')
-        modinifile=$(eval echo ${modINI})
         output=$($modfilepath -d -c "${modinifile}" $DEBUGCMD 2>&1)
         rc=$?
     else
         if ! test "$ALIGNAKSPECIFICCFG"
         then
-            output=$($modfilepath -d -c "$ALIGNAKCFG" $DEBUGCMD 2>&1)
+            output=$($modfilepath -d -c "${modinifile}" -a "$ALIGNAKCFG" $DEBUGCMD 2>&1)
         else
-            output=$($modfilepath -d -c "$ALIGNAKCFG" -c "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1)
+            output=$($modfilepath -d -c "${modinifile}" -a "$ALIGNAKCFG" -a "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1)
         fi
         rc=$?
     fi
@@ -363,12 +363,24 @@ do_stop() {
 # does the config check
 #
 do_check() {
+    echo  "Checking configuration..."
     [ "$DEBUG" = 1 ] && DEBUGCMD="--debug $VAR/${mod}-debug.log"
+
+    modINI=$(echo "$"${mod}CFG | tr '[:lower:]' '[:upper:]')
+    modinifile=$(eval echo ${modINI})
+
     if ! test "$ALIGNAKSPECIFICCFG"
     then
-       $BIN/alignak-arbiter -V -c "$ALIGNAKCFG" $DEBUGCMD 2>&1
+       $BIN/alignak-arbiter -V -c "${modinifile}" -a "$ALIGNAKCFG" $DEBUGCMD 2>&1
     else
-       $BIN/alignak-arbiter -V -c "$ALIGNAKCFG" -c "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1
+       $BIN/alignak-arbiter -V -c "${modinifile}" -a "$ALIGNAKCFG" -a "$ALIGNAKSPECIFICCFG" $DEBUGCMD 2>&1
+    fi
+    rc=$?
+    if [ $rc -eq 0 ]; then
+        echo_success
+    else
+        echo "$startoutput"
+        echo_failure
     fi
     return $?
 }
@@ -383,18 +395,6 @@ do_start_() {
     if [ $rc -eq 0 ]; then
         log_warning_msg "Already running"
         return
-    fi
-    if test "$1" = "arbiter"
-    then
-        # arbiter is special:
-        # it doesn't actually declare a "workdir" properties in its config
-        # so we have explicitely to cd to the "VAR" directory.
-        # so that the default pidfile ( == nagios lock_file) which is now "arbiterd.pid"
-        # will be created at the correct place.
-        cd "$VAR"
-        # TODO: check if other possibility wouldn't be better:
-        # declare a "workdir" properties for the arbiter module definition.. in alignak-specific.cfg.
-        # but if the lock_file path is absolute then this 'cd' isn't required.
     fi
     startoutput=$(do_start "$1")
     rc=$?
@@ -429,7 +429,6 @@ do_stop_() {
 
 do_restart_() {
     mod="$1"
-    echo "Restarting $mod"
     if [ "$mod" = "arbiter" ]; then
         do_check_ "$mod"
         checkrc=$?
@@ -437,6 +436,7 @@ do_restart_() {
            return 1
         fi
     fi
+    echo "Restarting $mod"
     stopoutput=$(do_stop "$mod")
     startoutput=$(do_start "$mod")
     rc=$?
@@ -455,21 +455,29 @@ do_force_reload_() {
 
 do_reload_() {
     mod="$1"
-    echo "Reloading $mod"
     if [ "$mod" = "arbiter" ]; then
+        do_status_ $mod
+        checkrc=$?
+        if [ $checkrc -ne 0 ]; then
+           echo "Cannot request reload if process is not running."
+           return 1
+        fi
         do_check_ "$mod"
         checkrc=$?
         if [ $checkrc -ne 0 ]; then
            return 1
         fi
         pid=$(getmodpid "$mod")
-        # send SIGHUP signal to reload configuration
-        kill -1 $pid
-        rc=$?
+        if [ "$pid" != "" ]; then
+            # send SIGHUP signal to reload configuration
+            kill -1 $pid
+            rc=$?
+        fi
     else
         # if not the arbiter module, reload == restart
         do_restart_ $mod
     fi
+    echo "Reloading $mod"
     if [ $rc -eq 0 ]; then
         echo_success
     else

--- a/bin/rc.d/alignak-arbiter
+++ b/bin/rc.d/alignak-arbiter
@@ -11,10 +11,11 @@
 name="alignak_arbiter"
 rcvar="alignak_arbiter_enable"
 
+alignak_arbiter_daemonfile="/usr/local/etc/alignak/daemons/arbiterd.ini"
 alignak_arbiter_configfile="/usr/local/etc/alignak/alignak.cfg"
 command="/usr/local/bin/alignak-arbiter"
 command_interpreter="/usr/local/bin/python2.7"
-command_args="-d -c ${alignak_arbiter_configfile} > /dev/null 2>&1"
+command_args="-d -c ${alignak_arbiter_daemonfile} -a ${alignak_arbiter_configfile} > /dev/null 2>&1"
 pidfile="/var/run/alignak/arbiterd.pid"
 
 restart_precmd="alignak_checkconfig"
@@ -29,7 +30,7 @@ load_rc_config "${name}"
 
 alignak_checkconfig() {
 	echo -n "Performing sanity check on alignak configuration: "
-	${command} -v -c ${alignak_arbiter_configfile} >/dev/null 2>&1
+	${command} -V -a ${alignak_arbiter_configfile} >/dev/null 2>&1
 	if [ $? -ne 0 ]; then
 		echo "FAILED"
 		return 1

--- a/dev/launch_arbiter.sh
+++ b/dev/launch_arbiter.sh
@@ -47,9 +47,5 @@ DIR="$(cd $(dirname "$0"); pwd)"
 BIN="$DIR"/../alignak/bin
 ETC="$DIR"/../etc
 
-# Need to change directory to .../var because arbiter doesn't have a
-# default 'workdir' "properties" attribute:.
-cd "$DIR/../var"
-
 echo "Launching Arbiter (which reads configuration and dispatches it)"
-"$BIN"/alignak_arbiter.py -d -c "$ETC"/alignak.cfg
+"$BIN"/alignak_arbiter.py -d -c "$ETC"/daemons/arbiterd.ini -a "$ETC"/alignak.cfg

--- a/dev/launch_arbiter_debug.sh
+++ b/dev/launch_arbiter_debug.sh
@@ -56,5 +56,6 @@ echo "Launching Arbiter (which reads configuration and dispatches it) " \
     "in debug mode to the file $DEBUG_PATH"
 
 "$BIN"/alignak_arbiter.py -d \
-    -c "$ETC"/alignak.cfg  -c "$ETC"/sample.cfg -c "$ETC"/dev.cfg\
+     -c "$ETC"/daemons/arbiterd.ini\
+     -a "$ETC"/alignak.cfg  -a "$ETC"/sample/sample.cfg\
     --debug "$DEBUG_PATH" -p /tmp/arbiter.profile

--- a/dev/restart_all.sh
+++ b/dev/restart_all.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+DIR="$(cd $(dirname "$0"); pwd)"
+"$DIR"/stop_all.sh
+sleep 3
+"$DIR"/launch_all.sh

--- a/etc/alignak.cfg
+++ b/etc/alignak.cfg
@@ -58,8 +58,43 @@ cfg_dir=arbiter/packs/resource.d
 # -------------------------------------------------------------------------
 # Alignak framework configuration part
 # -------------------------------------------------------------------------
+
+# Notifications configuration
+# ---
+# Notifications are enabled/disabled
+# enable_notifications=1
+
+# After a timeout, launched plugins are killed
+#notification_timeout=30
+
+
+# Retention configuration
+# ---
 # Number of minutes between 2 retention save, default is 60 minutes
 #retention_update_interval=60
+
+# Checks configuration
+# ---
+# Active host/service checks are enabled/disabled
+#execute_host_checks=1
+#execute_service_checks=1
+
+# Passive host/service checks are enabled/disabled
+#accept_passive_host_checks=1
+#accept_passive_service_checks=1
+
+# As default, passive host checks are HARD states
+#passive_host_checks_are_soft=0
+
+
+# Interval length and re-scheduling configuration
+# Do not change those values unless you are reaaly sure to master what you are doing ...
+#interval_length=60
+#auto_reschedule_checks=1
+auto_rescheduling_interval=1
+auto_rescheduling_window=180
+use_aggressive_host_checking=0
+
 
 # Number of interval to spread the first checks for hosts and services
 # Default is 30
@@ -70,10 +105,21 @@ max_service_check_spread=5
 max_host_check_spread=5
 
 
-# After a timeout, launched service checks are killed
+# Max plugin output for the plugins launched by the pollers, in bytes
+#max_plugins_output_length=8192
+max_plugins_output_length=65536
+
+
+# After a timeout, launched plugins are killed
+# and the host state is set to a default value (2 for DOWN)
 # and the service state is set to a default value (2 for CRITICAL)
+#host_check_timeout=30
 #service_check_timeout=60
 #timeout_exit_status=2
+#event_handler_timeout=30
+#notification_timeout=30
+#ocsp_timeout=15
+#ohsp_timeout=15
 
 
 # Freshness check
@@ -87,7 +133,8 @@ max_host_check_spread=5
 #additional_freshness_latency=15
 
 
-# Flapping detection
+# Flapping detection configuration
+# ---
 # Default is enabled
 #enable_flap_detection=1
 
@@ -101,19 +148,54 @@ max_host_check_spread=5
 # 20 by default, can be useful to increase it. Each flap_history increases cost:
 #    flap_history cost = 4Bytes * flap_history * (nb hosts + nb services)
 # Example: 4 * 20 * (1000+10000) ~ 900Ko for a quite big conf. So, go for it!
-flap_history=20
+#flap_history=20
 
 
-# Max plugin output for the plugins launched by the pollers, in bytes
-#max_plugins_output_length=8192
-max_plugins_output_length=65536
+# Performance data configuration
+# ---
+# Performance data management is enabled/disabled
+#process_performance_data=1
+
+# Performance data commands
+#host_perfdata_command=
+#service_perfdata_command=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
 
 
-# Enable or not the state change on impact detection (like
-# a host going unreachable if a parent is DOWN for example). It's for
-# services and hosts.
-# Remark: if this option is absent, the default is 0 (for Nagios
-# old behavior compatibility)
+# Event handlers configuration
+# ---
+# Event handlers are enabled/disabled
+#enable_event_handlers=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+# Global host/service event handlers
+#global_host_event_handler=
+#global_service_event_handler=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# External commands configuration
+# ---
+# External commands are enabled/disabled
+# check_external_commands=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+
+# Impacts configuration
+# ---
+# Enable or not the state change on impact detection (like a host going unreachable
+# if a parent is DOWN for example). It's for services and hosts.
+# Note: defaults to 0 for Nagios old behavior compatibility
 #enable_problem_impacts_states_change=0
 enable_problem_impacts_states_change=1
 
@@ -125,15 +207,15 @@ enable_problem_impacts_states_change=1
 disable_old_nagios_parameters_whining=1
 
 
-# If you need to set a specific timezone to your deamons, uncomment it
-#use_timezone=Europe/Paris
-
-
-# Disabling env macros is good for performances. If you really need it, enable it.
+# Environment macros configuration
+# ---
+# Disabling environment macros is good for performance. If you really need it, enable it.
 #enable_environment_macros=1
 enable_environment_macros=0
 
-# Log configuration
+
+# Monitoring log configuration
+# ---
 # Notifications
 # log_notifications=1
 
@@ -154,58 +236,30 @@ enable_environment_macros=0
 
 # Initial states
 # log_initial_states=1
-log_initial_states=0
-
-# By default don't launch even handlers during downtime. Put 0 to
-# get back the default nagios behavior
-no_event_handlers_during_downtimes=1
 
 
-# [Optionnal], a pack distribution file is a local file near the arbiter
+# [Optional], a pack distribution file is a local file near the arbiter
 # that will keep host pack id association, and so push same host on the same
 # scheduler if possible between restarts.
 pack_distribution_file=/usr/local/var/lib/alignak/pack_distribution.dat
 
 
+# If you need to set a specific timezone to your deamons, uncomment it
+#use_timezone=Europe/Paris
 
-# --------------------------------------------------------------------
-## Arbiter daemon part, similar to daemon ini file
-# --------------------------------------------------------------------
 
-#If not specified will use lockfile direname
-workdir=/usr/local/var/run/alignak
-
-# Lock file (with pid) for Arbiterd
-lock_file=/usr/local/var/run/alignak/arbiterd.pid
-
-# The arbiter can have it's own local log
-local_log=/usr/local/var/log/alignak/arbiterd.log
-
-# Accepted log level values: DEBUG,INFO,WARNING,ERROR,CRITICAL
-#log_level=WARNING
-
-# User that will be used by the arbiter.
-# If commented, run as current user (root?)
-#alignak_user=alignak
-#alignak_group=alignak
-
-# Set to 0 if you want to make this daemon (arbiter) NOT run
-daemon_enabled=1
-
-#-- Security using SSL --
-use_ssl=0
-# WARNING : Put full paths for certs
-# They are not shipped with alignak.
-# Have a look to proper tutorials to generate them
-#ca_cert=/etc/alignak/certs/ca.pem
-#server_cert=/etc/alignak/certs/server.cert
-#server_key=/etc/alignak/certs/server.key
-#hard_ssl_name_check=0
-
-# Export all alignak inner performances into a statsd server. 
+# Export all alignak inner performances into a statsd server.
 # By default at localhost:8125 (UDP) with the alignak prefix
 # Default is not enabled
 #statsd_host=localhost
 #statsd_port=8125
 #statsd_prefix=alignak
 #statsd_enabled=0
+
+
+# --------------------------------------------------------------------
+## Arbiter daemon part, similar to daemon ini file
+# --------------------------------------------------------------------
+#
+# Those parameters are defined in the arbiterd.ini file
+# 

--- a/etc/daemons/arbiterd.ini
+++ b/etc/daemons/arbiterd.ini
@@ -7,7 +7,7 @@
 workdir=/usr/local/var/run/alignak
 logdir=/usr/local/var/log/alignak
 
-pidfile=%(workdir)s/pollerd.pid
+pidfile=%(workdir)s/arbiterd.pid
 
 #-- Username and group to run (defaults to current user)
 #user=alignak
@@ -15,7 +15,7 @@ pidfile=%(workdir)s/pollerd.pid
 
 #-- Network configuration
 # host=0.0.0.0
-port=7771
+port=7770
 # idontcareaboutsecurity=0
 
 #-- Set to 0 if you want to make this daemon NOT run
@@ -32,7 +32,7 @@ use_ssl=0
 #-- Local log management --
 # Enabled by default to ease troubleshooting
 #use_local_log=1
-local_log=%(logdir)s/pollerd.log
+local_log=%(logdir)s/arbiterd.log
 # Log with a formatted human date
 #human_timestamp_log=1
 #human_date_format=%Y-%m-%d %H:%M:%S %Z

--- a/etc/daemons/brokerd.ini
+++ b/etc/daemons/brokerd.ini
@@ -31,10 +31,17 @@ use_ssl=0
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting
-use_local_log=1
+#use_local_log=1
 local_log=%(logdir)s/brokerd.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
 # accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+#log_level=INFO
 
 #-- External modules watchdog --
 # If a module got a brok queue() higher than this value, it will be

--- a/etc/daemons/reactionnerd.ini
+++ b/etc/daemons/reactionnerd.ini
@@ -31,7 +31,14 @@ use_ssl=0
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting
-use_local_log=1
+#use_local_log=1
 local_log=%(logdir)s/reactionnerd.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
 # accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+#log_level=INFO

--- a/etc/daemons/receiverd.ini
+++ b/etc/daemons/receiverd.ini
@@ -31,7 +31,14 @@ use_ssl=0
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting
-use_local_log=1
+#use_local_log=1
 local_log=%(logdir)s/receiverd.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
 # accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+#log_level=INFO

--- a/etc/daemons/schedulerd.ini
+++ b/etc/daemons/schedulerd.ini
@@ -35,7 +35,14 @@ use_ssl=0
 
 #-- Local log management --
 # Enabled by default to ease troubleshooting
-use_local_log=1
+#use_local_log=1
 local_log=%(logdir)s/schedulerd.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
 # accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
-log_level=WARNING
+#log_level=INFO

--- a/install_hooks.py
+++ b/install_hooks.py
@@ -176,8 +176,8 @@ def fix_alignak_cfg(config):
             print(line)
 
     # Handle daemons ini files
-    for ini_file in ["brokerd.ini", "schedulerd.ini", "pollerd.ini",
-                     "reactionnerd.ini", "receiverd.ini"]:
+    for ini_file in ["arbiterd.ini", "brokerd.ini", "schedulerd.ini",
+                     "pollerd.ini", "reactionnerd.ini", "receiverd.ini"]:
         # Prepare pattern for ini files
         daemon_name = ini_file.strip(".ini")
         default_paths['lock_file'] = '/var/run/alignak/%s.pid' % daemon_name

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -74,6 +74,31 @@ class TestConfig(AlignakTest):
         link = self.arbiter.conf.receivers.find_by_name('receiver-master')
         self.assertIsNotNone(link)
 
+    def test_config_conf_inner_properties(self):
+        """
+        Default configuration has no loading problems ... and inner default proerties are
+        correctly values
+
+        :return: None
+        """
+        self.print_header()
+        self.setup_with_file('cfg/cfg_default.cfg')
+        self.assertTrue(self.conf_is_correct)
+
+        # No error messages
+        self.assertEqual(len(self.configuration_errors), 0)
+        # No warning messages
+        self.assertEqual(len(self.configuration_warnings), 0)
+
+        # Arbiter configuration is correct
+        self.assertTrue(self.arbiter.conf.conf_is_correct)
+
+        # Configuration inner properties are valued
+        self.assertEqual(self.arbiter.conf.prefix, '')
+        self.assertEqual(self.arbiter.conf.main_config_file,
+                         os.path.abspath('cfg/cfg_default.cfg'))
+        self.assertEqual(self.arbiter.conf.config_base_dir, 'cfg')
+
     def test_config_ok_no_declared_daemons(self):
         """
         Default configuration has no loading problems ... but no daemons are defined

--- a/test/test_realms.py
+++ b/test/test_realms.py
@@ -72,8 +72,7 @@ class TestRealms(AlignakTest):
         # The following log line is not available in the test catched log, because too early
         # in the configuration load process
         # self.assert_any_log_match("WARNING: [Alignak] No realms defined, I add one as Default")
-        self.assert_any_log_match(re.escape("[alignak.dispatcher] "
-                                            "[All] Prepare dispatching this realm"))
+        self.assert_any_log_match(re.escape("Prepare dispatching this realm"))
 
         # Only one realm in the configuration
         self.assertEqual(len(self.arbiter.conf.realms), 1)


### PR DESCRIPTION
Refactor log module:
- remove Log class (and BrokHandler, and logs stacking)
- replace with a setup function that allows to define a Console and a RotatingFile handler
- allow to change log level and date format
- replace naglog_result function with make_monitoring_log function that returns a Brok
- allow to configure logger in the daemon configuration file

**Impacts:**
- base Daemon class and daemons logger configuration modified
- Arbiter now has its own arbiterd.ini file
- naglog_result is replaced with a function creating a Brok 

This pull request completes #386, replaces #411 and is linked to:
- #424 and #426: the Arbiter has its own configuration file as other daemons
- #409, #410, #413 and #414 for the logs refactoring process
