### PR TITLE
Add tests for log events

### DIFF
--- a/alignak/misc/logevent.py
+++ b/alignak/misc/logevent.py
@@ -90,15 +90,16 @@ EVENT_TYPES = {
     'DOWNTIME': {
         # ex: "[1279250211] HOST DOWNTIME ALERT:
         # maast64;STARTED; Host has entered a period of scheduled downtime"
-        'pattern': r'^\[([0-9]{10})\] (HOST|SERVICE) (DOWNTIME) ALERT: '
-        r'([^\;]*);(STARTED|STOPPED|CANCELLED);(.*)',
+        'pattern': r'^\[([0-9]{10})] (HOST|SERVICE) (DOWNTIME) ALERT: '
+        r'([^\;]*);(?:([^\;]*);)?([^\;]*);([^\;]*)',
         'properties': [
             'time',
-            'downtime_type',  # '(SERVICE or could be 'HOST')
-            'event_type',  # 'DOWNTIME'
-            'hostname',  # 'maast64'
-            'state',  # 'STARTED'
-            'output',  # 'Host has entered a period of scheduled downtime'
+            'downtime_type',  # 'SERVICE' or 'HOST'
+            'event_type',  # 'FLAPPING'
+            'hostname',  # The hostname
+            'service_desc',  # The service description or None
+            'state',  # 'STOPPED' or 'STARTED'
+            'output',  # 'Service appears to have started flapping (24% change >= 20.0% threshold)'
         ]
     },
     'FLAPPING': {
@@ -126,6 +127,8 @@ EVENT_TYPES = {
 class LogEvent:  # pylint: disable=R0903
     """Class for parsing event logs
     Populates self.data with the log type's properties
+
+    TODO: check that this class is still used somewhere
     """
 
     def __init__(self, log):

--- a/test/test_parse_logevent.py
+++ b/test/test_parse_logevent.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
+# Copyright (C) 2015-2015: Alignak team, see AUTHORS.txt file for contributors
 #
 # This file is part of Alignak.
 #
@@ -112,14 +112,29 @@ class TestParseLogEvent(AlignakTest):
         self.assertEqual(event.data, expected)
 
     def test_downtime_alert_host(self):
-        log = '[1279250211] HOST DOWNTIME ALERT: maast64;STARTED; Host has entered a period of scheduled downtime'
+        log = '[1279250211] HOST DOWNTIME ALERT: testhost;STARTED; Host has entered a period of scheduled downtime'
         expected = {
             'event_type': 'DOWNTIME',
-            'hostname': 'maast64',
+            'hostname': 'testhost',
+            'service_desc': None,
             'state': 'STARTED',
             'time': 1279250211,
             'output': ' Host has entered a period of scheduled downtime',
             'downtime_type': 'HOST'
+        }
+        event = LogEvent(log)
+        self.assertEqual(event.data, expected)
+
+    def test_downtime_alert_service(self):
+        log = '[1279250211] SERVICE DOWNTIME ALERT: testhost;check_ssh;STARTED; Service has entered a period of scheduled downtime'
+        expected = {
+            'event_type': 'DOWNTIME',
+            'hostname': 'testhost',
+            'service_desc': 'check_ssh',
+            'state': 'STARTED',
+            'time': 1279250211,
+            'output': ' Service has entered a period of scheduled downtime',
+            'downtime_type': 'SERVICE'
         }
         event = LogEvent(log)
         self.assertEqual(event.data, expected)


### PR DESCRIPTION
The LogEvent class does not seem to be used but keeping this class in Alignak seems interesting for modules that would parse the monitoring logs ... to be discussed, see #509
