### PR TITLE
[WiP] Fix #532: add realm name in the satellites

### DIFF
--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -163,8 +163,8 @@ class ArbiterInterface(GenericInterface):
                         if not hasattr(daemon, prop):
                             continue
                         val = getattr(daemon, prop)
-                        if prop == "realm" and hasattr(val, "realm_name"):
-                            env[prop] = val.realm_name
+                        if prop == "realm":
+                            continue
                         # give a try to a json able object
                         try:
                             json.dumps(val)

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -1749,6 +1749,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
                 for elt in lst:
                     if not hasattr(elt, 'realm'):
                         elt.realm = 'All'
+                        elt.realm_name = 'All'
                         logger.info("Tagging %s with realm %s", elt.get_name(), default.get_name())
 
     def fill_default_satellites(self):

--- a/alignak/objects/satellitelink.py
+++ b/alignak/objects/satellitelink.py
@@ -88,6 +88,8 @@ class SatelliteLink(Item):
         'realm':
             StringProp(default='', fill_brok=['full_status'],
                        brok_transformation=get_obj_name_two_args_and_void),
+        'realm_name':
+            StringProp(default=''),
         'satellitemap':
             DictProp(default={}, elts_prop=AddrProp, to_send=True, override=True),
         'use_ssl':
@@ -613,6 +615,7 @@ class SatelliteLinks(Items):
             # Check if what we get is OK or not
             if realm is not None:
                 satlink.realm = realm.uuid
+                satlink.realm_name = realm.get_name()
                 getattr(realm, '%ss' % satlink.my_type).append(satlink.uuid)
                 # case SatelliteLink has manage_sub_realms
                 if getattr(satlink, 'manage_sub_realms', False):

--- a/test/test_launch_daemons.py
+++ b/test/test_launch_daemons.py
@@ -326,6 +326,7 @@ class fullTest(AlignakTest):
             for daemon in daemons:
                 print(" - %s: %s", daemon['%s_name' % daemon_type], daemon['alive'])
                 self.assertTrue(daemon['alive'])
+                self.assertFalse('realm' in daemon)
                 self.assertTrue('realm_name' in daemon)
 
         print("Testing get_running_id")

--- a/test/test_launch_daemons.py
+++ b/test/test_launch_daemons.py
@@ -320,8 +320,13 @@ class fullTest(AlignakTest):
         raw_data = req.get("%s://localhost:%s/get_all_states" % (http, satellite_map['arbiter']), verify=False)
         data = raw_data.json()
         self.assertIsInstance(data, dict, "Data is not a dict!")
-        for name, _ in satellite_map.items():
-            self.assertTrue(data[name][0]['alive'])
+        for daemon_type in data:
+            daemons = data[daemon_type]
+            print("Got Alignak state for: %ss / %d instances" % (daemon_type, len(daemons)))
+            for daemon in daemons:
+                print(" - %s: %s", daemon['%s_name' % daemon_type], daemon['alive'])
+                self.assertTrue(daemon['alive'])
+                self.assertTrue('realm_name' in daemon)
 
         print("Testing get_running_id")
         for name, port in satellite_map.items():


### PR DESCRIPTION
This to allow the arbiter API to provide a realm uuid **and** a realm name 