### PR TITLE
Closes #582: submit to coveralls if python2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ after_success:
   # to get coverage data with relative paths and not absolute we have to
   # execute coveralls from the base directory of the project,
   # so we need to move the .coverage file here :
-  - if [[ $TEST_SUITE == 'unit' ]]; then mv test/.coverage . && coveralls debug && coveralls -v --rcfile=test/.coveragerc; fi
+  - echo "Python version: $TRAVIS_PYTHON_VERSION"
+  - if [[ $TEST_SUITE == 'unit' && $TRAVIS_PYTHON_VERSION == '2.7' ]]; then ./.travis/report_coveralls.sh; fi
 
 notifications:
   webhooks:

--- a/.travis/report_coveralls.sh
+++ b/.travis/report_coveralls.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ev
+
+mv test/.coverage .
+coveralls debug
+echo "Submitting coverage results to coveralls.io..."
+coveralls -v --rcfile=test/.coveragerc
+echo "Submitted"


### PR DESCRIPTION
Only submit coverage report to coveralls.io if:
 
 - unit tests succeeded
 - unit tests ran with Python 2.7