### PR TITLE
Test daemons realms

### DIFF
--- a/.travis/unit.sh
+++ b/.travis/unit.sh
@@ -6,10 +6,6 @@ cd test
 # Delete previously existing coverage results
 coverage erase
 
-# Declare a COVERAGE_PROCESS_START environment variable
-# This variable is used to allow coverage tests in the Alignak daemons started processes
-COVERAGE_PROCESS_START='.coveragerc'
-
 # Run test suite with py.test running its coverage plugin
 pytest --cov=alignak --cov-config .coveragerc test_*.py
 

--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -154,21 +154,6 @@ class InvalidPidFile(Exception):
 
 DEFAULT_WORK_DIR = './'
 
-try:  # pragma: no cover, exclude from code coverage
-    if os.environ.get('COVERAGE_PROCESS_START'):
-        print("***")
-        print("* Executing daemon test with code coverage enabled")
-        if 'coverage' not in sys.modules:
-            print("* coverage module is not loaded! Trying to import coverage module...")
-            import coverage
-
-            coverage.process_startup()
-            print("* coverage process started.")
-        print("***")
-except Exception as exp:  # pylint: disable=broad-except
-    print("Exception: %s", str(exp))
-    sys.exit(3)
-
 
 # pylint: disable=R0902
 class Daemon(object):

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -62,11 +62,12 @@ or the consume_check. It's a very important class!
 """
 # pylint: disable=C0302
 # pylint: disable=R0904
-import logging
+import os
 import re
 import random
 import time
 import traceback
+import logging
 
 from alignak.objects.item import Item
 from alignak.objects.commandcallitem import CommandCallItems
@@ -2613,6 +2614,9 @@ class SchedulingItem(Item):  # pylint: disable=R0902
                 state = self.business_rule.get_state(hosts, services)
                 check.output = self.get_business_rule_output(hosts, services,
                                                              macromodulations, timeperiods)
+                if 'TEST_LOG_ACTIONS' in os.environ:
+                    logger.warning("Resolved BR for '%s', output: %s",
+                                   self.get_full_name(), check.output)
             except Exception, err:  # pylint: disable=W0703
                 # Notifies the error, and return an UNKNOWN state.
                 check.output = "Error while re-evaluating business rule: %s" % err
@@ -2624,11 +2628,16 @@ class SchedulingItem(Item):  # pylint: disable=R0902
             state = 0
             check.execution_time = 0
             check.output = 'Host assumed to be UP'
+            if 'TEST_LOG_ACTIONS' in os.environ:
+                logger.warning("Set host %s as UP (internal check)", self.get_full_name())
         # Echo is just putting the same state again
         elif check.command == '_echo':
             state = self.state
             check.execution_time = 0
             check.output = self.output
+            if 'TEST_LOG_ACTIONS' in os.environ:
+                logger.warning("Echo the current state (%d) for %s ",
+                               self.state, self.get_full_name())
         check.long_output = check.output
         check.check_time = time.time()
         check.exit_status = state

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -913,7 +913,7 @@ class Scheduler(object):  # pylint: disable=R0902
                     logger.warning("Contact %s %s notification command '%s ' "
                                    "timed out after %d seconds",
                                    contact.contact_name,
-                                   item.__class__.my_type,
+                                   item.my_type,
                                    self.actions[action.uuid].command,
                                    int(execution_time))
                 elif action.exit_status != 0:
@@ -930,10 +930,17 @@ class Scheduler(object):  # pylint: disable=R0902
             try:
                 if action.status == 'timeout':
                     ref = self.find_item_by_id(self.checks[action.uuid].ref)
-                    action.output = "(%s Check Timed Out)" %\
-                                    ref.__class__.my_type.capitalize()  # pylint: disable=E1101
+                    action.output = "(%s %s check timed out)" % (
+                        ref.my_type, ref.get_full_name()
+                    )  # pylint: disable=E1101
                     action.long_output = action.output
                     action.exit_status = self.conf.timeout_exit_status
+                    logger.warning("Timeout raised for '%s' (check command for the %s '%s')"
+                                   ", check status code: %d, execution time: %d seconds",
+                                   action.command,
+                                   ref.my_type, ref.get_full_name(),
+                                   action.exit_status,
+                                   int(action.execution_time))
                 self.checks[action.uuid].get_return_from(action)
                 self.checks[action.uuid].status = 'waitconsume'
             except KeyError, exp:
@@ -950,7 +957,7 @@ class Scheduler(object):  # pylint: disable=R0902
                 if action.is_snapshot:
                     _type = 'snapshot'
                 ref = self.find_item_by_id(self.checks[action.uuid].ref)
-                logger.warning("%s %s command '%s ' timed out after %d seconds",
+                logger.warning("%s %s command '%s' timed out after %d seconds",
                                ref.__class__.my_type.capitalize(),  # pylint: disable=E1101
                                _type,
                                self.actions[action.uuid].command,

--- a/test/cfg/alignak_full_run_realms/README
+++ b/test/cfg/alignak_full_run_realms/README
@@ -1,0 +1,7 @@
+# This configuration is built as is:
+# - a localhost host that is checked with _internal host check and that has no services
+# - 3 hosts that are distributed in 3 realms: All, North and South
+# - each host has 5 services that each run the script ./dummy_command.sh
+# - services are: ok, warning, critical, unknown and timeout, thus to check that poller workers run correctly the checks action
+# - the 4 first services are run normally, the last one raises a timeout alert
+# - one more service that uses the internal _echo command that set the same state as the current one, thus the default initial state

--- a/test/cfg/alignak_full_run_realms/alignak.cfg
+++ b/test/cfg/alignak_full_run_realms/alignak.cfg
@@ -1,0 +1,255 @@
+# --------------------------------------------------------------------
+# Alignak main configuration file
+# --------------------------------------------------------------------
+# This file is the main file that will be loaded by Alignak on boot.
+# It is the entry point for the framework configuration.
+# --------------------------------------------------------------------
+# Please see the official project documentation for documentation about
+# the configuration:
+# http://alignak-doc.readthedocs.io/en/latest/04_configuration/index.html
+# --------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+# Monitored objects configuration part
+# -------------------------------------------------------------------------
+# Configuration files with common objects like commands, timeperiods,
+# or templates that are used by the host/service/contacts
+cfg_dir=arbiter/objects
+
+# Templates and packs for hosts, services and contacts
+cfg_dir=arbiter/templates
+
+# Alignak daemons and modules are loaded
+cfg_dir=arbiter/daemons
+
+# Alignak extra realms
+cfg_dir=arbiter/realms
+
+# You will find global MACROS into the files in those directories
+cfg_dir=arbiter/resource.d
+
+# -------------------------------------------------------------------------
+# Alignak framework configuration part
+# -------------------------------------------------------------------------
+
+# Notifications configuration
+# ---
+# Notifications are enabled/disabled
+# enable_notifications=1
+
+# After a timeout, launched plugins are killed
+#notification_timeout=30
+
+
+# Retention configuration
+# ---
+# Number of minutes between 2 retention save, default is 60 minutes
+#retention_update_interval=60
+
+# Checks configuration
+# ---
+# Active host/service checks are enabled/disabled
+#execute_host_checks=1
+#execute_service_checks=1
+
+# Passive host/service checks are enabled/disabled
+#accept_passive_host_checks=1
+#accept_passive_service_checks=1
+
+# As default, passive host checks are HARD states
+#passive_host_checks_are_soft=0
+
+
+# Interval length and re-scheduling configuration
+# Do not change those values unless you are reaaly sure to master what you are doing ...
+#interval_length=60
+#auto_reschedule_checks=1
+auto_rescheduling_interval=1
+auto_rescheduling_window=180
+
+
+# Number of interval to spread the first checks for hosts and services
+# Default is 30
+#max_service_check_spread=30
+max_service_check_spread=5
+# Default is 30
+#max_host_check_spread=30
+max_host_check_spread=5
+
+
+# Max plugin output for the plugins launched by the pollers, in bytes
+#max_plugins_output_length=8192
+max_plugins_output_length=65536
+
+
+# After a timeout, launched plugins are killed
+# and the host state is set to a default value (2 for DOWN)
+# and the service state is set to a default value (2 for CRITICAL)
+#host_check_timeout=30
+##### Set to 5 for tests
+host_check_timeout=5
+#service_check_timeout=60
+##### Set to 5 for tests
+service_check_timeout=5
+#timeout_exit_status=2
+#event_handler_timeout=30
+#notification_timeout=30
+#ocsp_timeout=15
+#ohsp_timeout=15
+
+
+# Freshness check
+# Default is enabled for hosts and services
+#check_host_freshness=1
+#check_service_freshness=1
+# Default is 60 for hosts and services
+#host_freshness_check_interval=60
+#service_freshness_check_interval=60
+# Extra time for freshness check ...
+#additional_freshness_latency=15
+
+
+# Flapping detection configuration
+# ---
+# Default is enabled
+#enable_flap_detection=1
+
+# Flapping threshold for hosts and services
+#low_service_flap_threshold=20
+#high_service_flap_threshold=30
+#low_host_flap_threshold=20
+#high_host_flap_threshold=30
+
+# flap_history is the lengh of history states we keep to look for flapping.
+# 20 by default, can be useful to increase it. Each flap_history increases cost:
+#    flap_history cost = 4Bytes * flap_history * (nb hosts + nb services)
+# Example: 4 * 20 * (1000+10000) ~ 900Ko for a quite big conf. So, go for it!
+#flap_history=20
+
+
+# Performance data configuration
+# ---
+# Performance data management is enabled/disabled
+#process_performance_data=1
+
+# Performance data commands
+#host_perfdata_command=
+#service_perfdata_command=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# Event handlers configuration
+# ---
+# Event handlers are enabled/disabled
+#enable_event_handlers=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+# Global host/service event handlers
+#global_host_event_handler=
+#global_service_event_handler=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# External commands configuration
+# ---
+# External commands are enabled/disabled
+# check_external_commands=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+
+# Impacts configuration
+# ---
+# Enable or not the state change on impact detection (like a host going unreachable
+# if a parent is DOWN for example). It's for services and hosts.
+# Note: defaults to 0 for Nagios old behavior compatibility
+#enable_problem_impacts_states_change=0
+enable_problem_impacts_states_change=1
+
+
+# if 1, disable all notice and warning messages at
+# configuration checking when arbiter checks the configuration.
+# Default is to log the notices and warnings
+#disable_old_nagios_parameters_whining=0
+disable_old_nagios_parameters_whining=1
+
+
+# Environment macros configuration
+# ---
+# Disabling environment macros is good for performance. If you really need it, enable it.
+#enable_environment_macros=1
+enable_environment_macros=0
+
+
+# Monitoring log configuration
+# ---
+# Note that alerts and downtimes are always logged
+# ---
+# Notifications
+# log_notifications=1
+
+# Services retries
+# log_service_retries=1
+
+# Hosts retries
+# log_host_retries=1
+
+# Event handlers
+# log_event_handlers=1
+
+# Flappings
+# log_flappings=1
+
+# Snapshots
+# log_snapshots=1
+
+# External commands
+# log_external_commands=1
+
+# Active checks
+# log_active_checks=0
+
+# Passive checks
+# log_passive_checks=0
+
+# Initial states
+# log_initial_states=1
+
+
+# [Optional], a pack distribution file is a local file near the arbiter
+# that will keep host pack id association, and so push same host on the same
+# scheduler if possible between restarts.
+pack_distribution_file=/tmp/var/lib/alignak/pack_distribution.dat
+
+
+# If you need to set a specific timezone to your deamons, uncomment it
+#use_timezone=Europe/Paris
+
+
+# --------------------------------------------------------------------
+## Alignak internal metrics
+# --------------------------------------------------------------------
+# Export all alignak inner performances into a statsd server.
+# By default at localhost:8125 (UDP) with the alignak prefix
+# Default is not enabled
+#statsd_host=localhost
+#statsd_port=8125
+#statsd_prefix=alignak
+#statsd_enabled=0
+
+
+# --------------------------------------------------------------------
+## Arbiter daemon part, similar to daemon ini file
+# --------------------------------------------------------------------
+#
+# Those parameters are defined in the arbiterd.ini file
+# 

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/arbiter-master.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/arbiter-master.cfg
@@ -1,0 +1,43 @@
+#===============================================================================
+# ARBITER
+#===============================================================================
+# Description: The Arbiter is responsible for:
+# - Loading, manipulating and dispatching the configuration
+# - Validating the health of all other Alignak daemons
+# - Issuing global directives to Alignak daemons (kill, activate-spare, etc.)
+# https://alignak.readthedocs.org/en/latest/08_configobjects/arbiter.html
+#===============================================================================
+# IMPORTANT: If you use several arbiters you MUST set the host_name on each
+# servers to its real DNS name ('hostname' command).
+#===============================================================================
+define arbiter {
+    arbiter_name            arbiter-master
+    #host_name              node1           ; CHANGE THIS if you have several Arbiters (like with a spare)
+    address                 127.0.0.1
+    port                    7770
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    ## Interesting modules:
+    # - backend_arbiter     = get the monitored objects configuration from the Alignak backend
+    #modules                 backend_arbiter
+
+    ## Optional parameters:
+    ## Uncomment these lines in a HA architecture so the master and slaves know
+    ## how long they may wait for each other.
+    #timeout                 3   ; Ping timeout
+    #data_timeout            120 ; Data send timeout
+    #max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    #check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/broker-master.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/broker-master.cfg
@@ -1,0 +1,48 @@
+#===============================================================================
+# BROKER (S1_Broker)
+#===============================================================================
+# Description: The broker is responsible for:
+# - Exporting centralized logs of all Alignak daemon processes
+# - Exporting status data
+# - Exporting performance data
+# - Exposing Alignak APIs:
+#   - Status data
+#   - Performance data
+#   - Configuration data
+#   - Command interface
+# https://alignak.readthedocs.org/en/latest/08_configobjects/broker.html
+#===============================================================================
+define broker {
+    broker_name             broker-master
+    address                 127.0.0.1
+    port                    7772
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_broker      = update the live state in the Alignak backend
+    # - logs                = create a log for all monitoring events (alerts, acknowledges, ...)
+    #modules                 backend_broker, logs
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_arbiters         1   ; Take data from Arbiter. There should be only one
+                                ; broker for the arbiter.
+    manage_sub_realms       1   ; Does it take jobs from schedulers of sub-Realms?
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/broker-north.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/broker-north.cfg
@@ -1,0 +1,48 @@
+#===============================================================================
+# BROKER (S1_Broker)
+#===============================================================================
+# Description: The broker is responsible for:
+# - Exporting centralized logs of all Alignak daemon processes
+# - Exporting status data
+# - Exporting performance data
+# - Exposing Alignak APIs:
+#   - Status data
+#   - Performance data
+#   - Configuration data
+#   - Command interface
+# https://alignak.readthedocs.org/en/latest/08_configobjects/broker.html
+#===============================================================================
+define broker {
+    broker_name             broker-north
+    address                 127.0.0.1
+    port                    17772
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_broker      = update the live state in the Alignak backend
+    #modules                 backend_broker
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_arbiters         0   ; Take data from Arbiter. There should be only one
+                                ; broker for the arbiter.
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/broker-south.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/broker-south.cfg
@@ -1,0 +1,48 @@
+#===============================================================================
+# BROKER (S1_Broker)
+#===============================================================================
+# Description: The broker is responsible for:
+# - Exporting centralized logs of all Alignak daemon processes
+# - Exporting status data
+# - Exporting performance data
+# - Exposing Alignak APIs:
+#   - Status data
+#   - Performance data
+#   - Configuration data
+#   - Command interface
+# https://alignak.readthedocs.org/en/latest/08_configobjects/broker.html
+#===============================================================================
+define broker {
+    broker_name             broker-south
+    address                 127.0.0.1
+    port                    27772
+
+    ## Realm
+    realm                   South
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_broker      = update the live state in the Alignak backend
+    #modules                 backend_broker
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_arbiters         0   ; Take data from Arbiter. There should be only one
+                                ; broker for the arbiter.
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/poller-master.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/poller-master.cfg
@@ -1,0 +1,54 @@
+#===============================================================================
+# POLLER (S1_Poller)
+#===============================================================================
+# Description: The poller is responsible for:
+# - Active data acquisition
+# - Local passive data acquisition
+# https://alignak.readthedocs.org/en/latest/08_configobjects/poller.html
+#===============================================================================
+define poller {
+    poller_name             poller-master
+    address                 127.0.0.1
+    port                    7771
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    ## Interesting modules:
+    # - nrpe-booster        = Replaces the check_nrpe binary. Therefore it
+    #                       enhances performances when there are lot of NRPE
+    #                       calls.
+    # - snmp-booster        = Snmp bulk polling module
+    #modules
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    ## In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers             0   ; Starts with N processes (0 = 1 per CPU)
+    max_workers             0   ; No more than N processes (0 = 1 per CPU)
+    processes_by_worker     256 ; Each worker manages N checks
+    polling_interval        1   ; Get jobs from schedulers each N seconds
+
+    #passive                0   ; For DMZ monitoring, set to 1 so the connections
+                                ; will be from scheduler -> poller.
+
+    # Poller tags are the tag that the poller will manage. Use None as tag name to manage
+    # untagged checks
+    #poller_tags             None
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/poller-north.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/poller-north.cfg
@@ -1,0 +1,58 @@
+#===============================================================================
+# POLLER (S1_Poller)
+#===============================================================================
+# Description: The poller is responsible for:
+# - Active data acquisition
+# - Local passive data acquisition
+# https://alignak.readthedocs.org/en/latest/08_configobjects/poller.html
+#===============================================================================
+define poller {
+    poller_name             poller-north
+    address                 127.0.0.1
+    port                    17771
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    ## Interesting modules:
+    # - booster-nrpe        = Replaces the check_nrpe binary. Therefore it
+    #                       enhances performances when there are lot of NRPE
+    #                       calls.
+    # - named-pipe          = Allow the poller to read a nagios.cmd named pipe.
+    #                       This permits the use of distributed check_mk checks
+    #                       should you desire it.
+    # - snmp-booster        = Snmp bulk polling module
+    modules
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    ## In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers             0   ; Starts with N processes (0 = 1 per CPU)
+    max_workers             0   ; No more than N processes (0 = 1 per CPU)
+    processes_by_worker     256 ; Each worker manages N checks
+    polling_interval        1   ; Get jobs from schedulers each N seconds
+
+    #passive                0   ; For DMZ monitoring, set to 1 so the connections
+                                ; will be from scheduler -> poller.
+
+    # Poller tags are the tag that the poller will manage. Use None as tag name to manage
+    # untagged checks
+    #poller_tags             None
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/poller-south.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/poller-south.cfg
@@ -1,0 +1,58 @@
+#===============================================================================
+# POLLER (S1_Poller)
+#===============================================================================
+# Description: The poller is responsible for:
+# - Active data acquisition
+# - Local passive data acquisition
+# https://alignak.readthedocs.org/en/latest/08_configobjects/poller.html
+#===============================================================================
+define poller {
+    poller_name             poller-south
+    address                 127.0.0.1
+    port                    27771
+
+    ## Realm
+    realm                   South
+
+    ## Modules
+    # Default: None
+    ## Interesting modules:
+    # - booster-nrpe        = Replaces the check_nrpe binary. Therefore it
+    #                       enhances performances when there are lot of NRPE
+    #                       calls.
+    # - named-pipe          = Allow the poller to read a nagios.cmd named pipe.
+    #                       This permits the use of distributed check_mk checks
+    #                       should you desire it.
+    # - snmp-booster        = Snmp bulk polling module
+    modules
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    ## In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers             0   ; Starts with N processes (0 = 1 per CPU)
+    max_workers             0   ; No more than N processes (0 = 1 per CPU)
+    processes_by_worker     256 ; Each worker manages N checks
+    polling_interval        1   ; Get jobs from schedulers each N seconds
+
+    #passive                0   ; For DMZ monitoring, set to 1 so the connections
+                                ; will be from scheduler -> poller.
+
+    # Poller tags are the tag that the poller will manage. Use None as tag name to manage
+    # untagged checks
+    #poller_tags             None
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/reactionner-master.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/reactionner-master.cfg
@@ -1,0 +1,45 @@
+#===============================================================================
+# REACTIONNER (S1_Reactionner)
+#===============================================================================
+# Description: The reactionner is responsible for:
+# - Executing notification actions
+# - Executing event handler actions
+# https://alignak.readthedocs.org/en/latest/08_configobjects/reactionner.html
+#===============================================================================
+define reactionner {
+    reactionner_name        reactionner-master
+    address                 127.0.0.1
+    port                    7769
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    #modules
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers             1   ; Starts with N processes (0 = 1 per CPU)
+    max_workers             15  ; No more than N processes (0 = 1 per CPU)
+    polling_interval        1   ; Get jobs from schedulers each 1 second
+
+    # Reactionner tags are the tag that the reactionner will manage. Use None as tag name to manage
+    # untagged notification/event handlers
+    #reactionner_tags        None
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/receiver-master.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/receiver-master.cfg
@@ -1,0 +1,44 @@
+#===============================================================================
+# RECEIVER
+#===============================================================================
+# The receiver manages passive information. It's just a "buffer" which will
+# load passive modules (like NSCA) and be read by the arbiter to dispatch data.
+#===============================================================================
+define receiver {
+    receiver_name           receiver-master
+    address                 127.0.0.1
+    port                    7773
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - nsca                = NSCA protocol server for collecting passive checks
+    # - external-commands   = read a nagios commands file to notify external commands
+    # - web-services        = expose Web services to get Alignak daemons state and
+    #                         notify external commands
+    #modules                 nsca
+
+    ## Optional parameters
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Feature
+    direct_routing          1   ; If enabled, it will directly send commands to the
+                                ; schedulers if it knows about the hostname in the
+                                ; command.
+                                ; If not the arbiter will get the information from
+                                ; the receiver.
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/receiver-north.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/receiver-north.cfg
@@ -1,0 +1,42 @@
+#===============================================================================
+# RECEIVER
+#===============================================================================
+# The receiver manages passive information. It's just a "buffer" which will
+# load passive modules (like NSCA) and be read by the arbiter to dispatch data.
+#===============================================================================
+define receiver {
+    receiver_name           receiver-north
+    address                 127.0.0.1
+    port                    17773
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - nsca                = NSCA protocol server for collecting passive checks
+    #modules                 nsca_north
+
+    ## Optional parameters
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Feature
+    direct_routing          1   ; If enabled, it will directly send commands to the
+                                ; schedulers if it knows about the hostname in the
+                                ; command.
+                                ; If not the arbiter will get the information from
+                                ; the receiver.
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/scheduler-master.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/scheduler-master.cfg
@@ -1,0 +1,54 @@
+#===============================================================================
+# SCHEDULER (S1_Scheduler)
+#===============================================================================
+# The scheduler is a "Host manager". It gets the hosts and their services,
+# schedules the checks and transmit them to the pollers.
+# Description: The scheduler is responsible for:
+# - Creating the dependancy tree
+# - Scheduling checks
+# - Calculating states
+# - Requesting actions from a reactionner
+# - Buffering and forwarding results its associated broker
+# https://alignak.readthedocs.org/en/latest/08_configobjects/scheduler.html
+#===============================================================================
+define scheduler {
+    scheduler_name          scheduler-master
+    address                 127.0.0.1
+    port                    7768
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_scheduler   = store the live state in the Alignak backend (retention)
+    #modules                 backend_scheduler
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Features:
+    # Skip initial broks creation. Boot fast, but some broker modules won't
+    # work with it! (like livestatus for example)
+    skip_initial_broks      0
+
+    # Some schedulers can manage more hosts than others
+    weight                  1
+
+    # In NATted environments, you declare each satellite ip[:port] as seen by
+    # *this* scheduler (if port not set, the port declared by satellite itself
+    # is used)
+    #satellitemap    poller-1=1.2.3.4:7771, reactionner-1=1.2.3.5:7769, ...
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/scheduler-north.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/scheduler-north.cfg
@@ -1,0 +1,55 @@
+#===============================================================================
+# SCHEDULER (S1_Scheduler)
+#===============================================================================
+# The scheduler is a "Host manager". It gets the hosts and their services,
+# schedules the checks and transmit them to the pollers.
+# Description: The scheduler is responsible for:
+# - Creating the dependancy tree
+# - Scheduling checks
+# - Calculating states
+# - Requesting actions from a reactionner
+# - Buffering and forwarding results its associated broker
+# https://alignak.readthedocs.org/en/latest/08_configobjects/scheduler.html
+#===============================================================================
+define scheduler {
+    scheduler_name          scheduler-north
+    address                 127.0.0.1
+    port                    17768
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_scheduler   = store the live state in the Alignak backend (retention)
+    #modules                 backend_scheduler
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Features:
+    # Skip initial broks creation. Boot fast, but some broker modules won't
+    # work with it! (like livestatus for example)
+    skip_initial_broks      0
+
+    # Some schedulers can manage more hosts than others
+    weight                  1
+
+    # In NATted environments, you declare each satellite ip[:port] as seen by
+    # *this* scheduler (if port not set, the port declared by satellite itself
+    # is used)
+    #satellitemap    poller-1=1.2.3.4:7771, reactionner-1=1.2.3.5:7769, ...
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/daemons/scheduler-south.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/daemons/scheduler-south.cfg
@@ -1,0 +1,55 @@
+#===============================================================================
+# SCHEDULER (S1_Scheduler)
+#===============================================================================
+# The scheduler is a "Host manager". It gets the hosts and their services,
+# schedules the checks and transmit them to the pollers.
+# Description: The scheduler is responsible for:
+# - Creating the dependancy tree
+# - Scheduling checks
+# - Calculating states
+# - Requesting actions from a reactionner
+# - Buffering and forwarding results its associated broker
+# https://alignak.readthedocs.org/en/latest/08_configobjects/scheduler.html
+#===============================================================================
+define scheduler {
+    scheduler_name          scheduler-south
+    address                 127.0.0.1
+    port                    27768
+
+    ## Realm
+    realm                   South
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_scheduler   = store the live state in the Alignak backend (retention)
+    #modules                 backend_scheduler
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Features:
+    # Skip initial broks creation. Boot fast, but some broker modules won't
+    # work with it! (like livestatus for example)
+    skip_initial_broks      0
+
+    # Some schedulers can manage more hosts than others
+    weight                  1
+
+    # In NATted environments, you declare each satellite ip[:port] as seen by
+    # *this* scheduler (if port not set, the port declared by satellite itself
+    # is used)
+    #satellitemap    poller-1=1.2.3.4:7771, reactionner-1=1.2.3.5:7769, ...
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/commands/detailled-host-by-email.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/commands/detailled-host-by-email.cfg
@@ -1,0 +1,6 @@
+## Notify Host by Email with detailled informations
+# Service have appropriate macros. Look at unix-fs pack to get an example
+define command {
+    command_name    detailled-host-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nType:$NOTIFICATIONTYPE$\nHost: $HOSTNAME$\nState: $HOSTSTATE$\nAddress: $HOSTADDRESS$\nDate/Time: $DATE$/$TIME$\n Host Output : $HOSTOUTPUT$\n\nHost description: $_HOSTDESC$\nHost Impact: $_HOSTIMPACT$" | /usr/bin/mail -s "Host $HOSTSTATE$ alert for $HOSTNAME$" $CONTACTEMAIL$
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/commands/detailled-service-by-email.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/commands/detailled-service-by-email.cfg
@@ -1,0 +1,7 @@
+
+## Notify Service by Email with detailled informations
+# Service have appropriate macros. Look at unix-fs pack to get an example
+define command {
+    command_name    detailled-service-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nNotification Type: $NOTIFICATIONTYPE$\n\nService: $SERVICEDESC$\nHost: $HOSTALIAS$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\n\nDate/Time: $DATE$ at $TIME$\nService Output : $SERVICEOUTPUT$\n\nService Description: $_SERVICEDETAILLEDESC$\nService Impact: $_SERVICEIMPACT$\nFix actions: $_SERVICEFIXACTIONS$" | /usr/bin/mail -s "$SERVICESTATE$ on Host : $HOSTALIAS$/Service : $SERVICEDESC$" $CONTACTEMAIL$
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/commands/dummy_check.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/commands/dummy_check.cfg
@@ -1,0 +1,6 @@
+## Notify Host by Email with detailled informations
+# Service have appropriate macros. Look at unix-fs pack to get an example
+define command {
+    command_name    dummy_check
+    command_line    /tmp/dummy_command.sh $ARG1$ $ARG2$
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/commands/notify-host-by-email.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/commands/notify-host-by-email.cfg
@@ -1,0 +1,5 @@
+## Notify Host by Email
+define command {
+    command_name    notify-host-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nType:$NOTIFICATIONTYPE$\nHost: $HOSTNAME$\nState: $HOSTSTATE$\nAddress: $HOSTADDRESS$\nInfo: $HOSTOUTPUT$\nDate/Time: $DATE$ $TIME$\n" | /usr/bin/mail -s "Host $HOSTSTATE$ alert for $HOSTNAME$" $CONTACTEMAIL$
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/commands/notify-service-by-email.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/commands/notify-service-by-email.cfg
@@ -1,0 +1,6 @@
+## Notify Service by Email
+define command {
+    command_name    notify-service-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nNotification Type: $NOTIFICATIONTYPE$\n\nService: $SERVICEDESC$\nHost: $HOSTNAME$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\n\nDate/Time: $DATE$ $TIME$\nAdditional Info : $SERVICEOUTPUT$\n" | /usr/bin/mail -s "** $NOTIFICATIONTYPE$ alert - $HOSTNAME$/$SERVICEDESC$ is $SERVICESTATE$ **" $CONTACTEMAIL$
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/contactgroups/admins.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/contactgroups/admins.cfg
@@ -1,0 +1,5 @@
+define contactgroup{
+    contactgroup_name   admins
+    alias               Administrators
+    members             admin
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/contactgroups/users.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/contactgroups/users.cfg
@@ -1,0 +1,5 @@
+define contactgroup{
+    contactgroup_name   users
+    alias               Guest users
+    members             guest
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/contacts/admin.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/contacts/admin.cfg
@@ -1,0 +1,11 @@
+define contact{
+    use                 generic-contact
+    contact_name        admin
+    alias               Administrator
+    email               frederic.mohier@alignak.net
+    pager               0600000000   ; contact phone number
+    password            admin
+    is_admin            1
+    ;can_submit_commands     1 (implicit because is_admin)
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/contacts/guest.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/contacts/guest.cfg
@@ -1,0 +1,9 @@
+define contact{
+    use                 generic-contact
+    contact_name        guest
+    alias               Guest
+    email               guest@localhost
+    password            guest
+    is_admin                0
+    can_submit_commands 0
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/hosts/localhost.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/hosts/localhost.cfg
@@ -1,0 +1,28 @@
+define host{
+    use                     generic-host
+    contact_groups          admins
+    host_name               localhost
+    alias                   Web UI
+    display_name            Alignak Web UI
+    address                 127.0.0.1
+
+    hostgroups              monitoring_servers
+
+    # Web UI host importance
+    # Business impact (from 0 to 5)
+    business_impact          4
+
+    # Web UI map position
+    # GPS coordinates
+    _LOC_LAT                 48.858561
+    _LOC_LNG                 2.294449
+
+    # Web UI notes, actions, ...
+    notes                    simple note
+    notes                    Label::note with a label
+    notes                    KB1023,,tag::<strong>Lorem ipsum dolor sit amet</strong>, consectetur adipiscing elit. Proin et leo gravida, lobortis nunc nec, imperdiet odio. Vivamus quam velit, scelerisque nec egestas et, semper ut massa. Vestibulum id tincidunt lacus. Ut in arcu at ex egestas vestibulum eu non sapien. Nulla facilisi. Aliquam non blandit tellus, non luctus tortor. Mauris tortor libero, egestas quis rhoncus in, sollicitudin et tortor.|note simple|Tag::tagged note ...
+
+    notes_url                http://www.my-KB.fr?host=$HOSTADDRESS$|http://www.my-KB.fr?host=$HOSTNAME$
+
+    action_url               On a map,,globe::<strong>Viw it on a map</strong>,,https://www.google.fr/maps/place/Tour+Eiffel/@48.8583701,2.2939341,19z/data=!3m1!4b1!4m5!3m4!1s0x47e66e2964e34e2d:0x8ddca9ee380ef7e0!8m2!3d48.8583701!4d2.2944813
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/notificationways/detailled-email.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/notificationways/detailled-email.cfg
@@ -1,0 +1,12 @@
+# This is how emails are sent, 24x7 way.
+define notificationway{
+   notificationway_name            detailled-email
+   service_notification_period     24x7
+   host_notification_period        24x7
+   service_notification_options    c,w,r
+   host_notification_options       d,u,r,f,s
+   service_notification_commands   detailled-service-by-email ; send service notifications via email
+   host_notification_commands      detailled-host-by-email    ; send host notifications via email
+   min_business_impact             1
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/notificationways/email.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/notificationways/email.cfg
@@ -1,0 +1,11 @@
+# This is how emails are sent, 24x7 way.
+define notificationway{
+       notificationway_name            email
+       service_notification_period     24x7
+       host_notification_period        24x7
+       service_notification_options    c,w,r
+       host_notification_options       d,u,r,f,s
+       service_notification_commands   notify-service-by-email ; send service notifications via email
+       host_notification_commands      notify-host-by-email    ; send host notifications via email
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/24x7.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/24x7.cfg
@@ -1,0 +1,12 @@
+define timeperiod{
+	timeperiod_name			24x7
+	alias				Always
+	sunday				00:00-24:00
+	monday				00:00-24:00
+	tuesday				00:00-24:00
+	wednesday			00:00-24:00
+	thursday			00:00-24:00
+	friday				00:00-24:00
+	saturday			00:00-24:00
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/none.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/none.cfg
@@ -1,0 +1,5 @@
+# 'none' timeperiod definition
+define timeperiod{
+	timeperiod_name	none
+	alias		No Time Is A Good Time
+	}

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/us-holidays.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/us-holidays.cfg
@@ -1,0 +1,16 @@
+# Some U.S. holidays
+# Note: The timeranges for each holiday are meant to *exclude* the holidays from being
+# treated as a valid time for notifications, etc.  You probably don't want your pager
+# going off on New Year's.  Although you're employer might... :-)
+define timeperiod{
+	name			us-holidays
+        timeperiod_name         us-holidays
+        alias                   U.S. Holidays
+
+        january 1               00:00-00:00     ; New Years
+        monday -1 may           00:00-00:00     ; Memorial Day (last Monday in May)
+        july 4                  00:00-00:00     ; Independence Day
+        monday 1 september      00:00-00:00     ; Labor Day (first Monday in September)
+        thursday -1 november    00:00-00:00     ; Thanksgiving (last Thursday in November)
+        december 25             00:00-00:00     ; Christmas
+        }

--- a/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/workhours.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/objects/timeperiods/workhours.cfg
@@ -1,0 +1,10 @@
+# 'workhours' timeperiod definition
+define timeperiod{
+	timeperiod_name	workhours
+	alias		Normal Work Hours
+	monday		09:00-17:00
+	tuesday		09:00-17:00
+	wednesday	09:00-17:00
+	thursday	09:00-17:00
+	friday		09:00-17:00
+	}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/All/hosts.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/All/hosts.cfg
@@ -1,0 +1,10 @@
+define host{
+    use                     generic-host
+    contact_groups          admins
+    host_name               alignak-all-00
+    alias                   Alignak
+    display_name            Alignak (Demo)
+    address                 127.0.0.1
+
+    check_command           dummy_check
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/All/realm.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/All/realm.cfg
@@ -1,0 +1,7 @@
+# Very advanced feature for multisite management.
+# Read the docs VERY CAREFULLY before changing these settings :)
+define realm {
+    realm_name      All
+    default         1
+    realm_members   North,South
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/All/services.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/All/services.cfg
@@ -1,0 +1,36 @@
+define service{
+  check_command                  _echo
+  host_name                      alignak-all-00
+  service_description            dummy_echo
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!0
+  host_name                      alignak-all-00
+  service_description            dummy_ok
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!1
+  host_name                      alignak-all-00
+  service_description            dummy_warning
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!2
+  host_name                      alignak-all-00
+  service_description            dummy_critical
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check
+  host_name                      alignak-all-00
+  service_description            dummy_unknown
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!0!10
+  host_name                      alignak-all-00
+  service_description            dummy_timeout
+  use                            generic-service
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/North/contacts.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/North/contacts.cfg
@@ -1,0 +1,33 @@
+# Contact definition
+# By default the contact will ask notification by mails
+define contact{
+    name                            north-contact
+    host_notifications_enabled	    1
+    service_notifications_enabled   1
+    email                           alignak@localhost
+    can_submit_commands		        1
+    notificationways        	    email
+    register                        0
+}
+
+define contactgroup{
+    contactgroup_name               north
+    alias                           North contacts
+}
+
+# This is a North contact
+define contact{
+    use                             north-contact
+    contact_name                    northman
+    alias                           North contact
+    email                           north@alignak.net
+    pager                           0600000000   ; contact phone number
+    password                        north
+    is_admin                        0
+    can_submit_commands             1
+
+    contactgroups                   north
+
+    # User address6 to set the user's realm when he is imported in the backend
+    address6                        North
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/North/hosts.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/North/hosts.cfg
@@ -1,0 +1,11 @@
+define host{
+    use                     generic-host
+    contact_groups          admins
+    host_name               alignak-north-00
+    alias                   Alignak
+    display_name            Alignak (Demo)
+    address                 127.0.0.1
+
+    check_command           dummy_check!0
+    realm                   North
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/North/realm.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/North/realm.cfg
@@ -1,0 +1,4 @@
+define realm {
+    realm_name    North
+    alias         North country
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/North/services.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/North/services.cfg
@@ -1,0 +1,36 @@
+define service{
+  check_command                  _echo
+  host_name                      alignak-north-00
+  service_description            dummy_echo
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!0
+  host_name                      alignak-north-00
+  service_description            dummy_ok
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!1
+  host_name                      alignak-north-00
+  service_description            dummy_warning
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!2
+  host_name                      alignak-north-00
+  service_description            dummy_critical
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check
+  host_name                      alignak-north-00
+  service_description            dummy_unknown
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!0!10
+  host_name                      alignak-north-00
+  service_description            dummy_timeout
+  use                            generic-service
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/South/contacts.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/South/contacts.cfg
@@ -1,0 +1,33 @@
+# Contact definition
+# By default the contact will ask notification by mails
+define contact{
+    name                            south-contact
+    host_notifications_enabled	    1
+    service_notifications_enabled   1
+    can_submit_commands		        1
+    notificationways        	    email
+    register                        0
+}
+
+define contactgroup{
+    contactgroup_name               south
+    alias                           South contacts
+}
+
+# This is a North contact
+define contact{
+    use                             south-contact
+    contact_name                    southhman
+    alias                           South contact
+    email                           south@alignak.net
+    pager                           0600000000   ; contact phone number
+    password                        south
+    is_admin                        0
+    can_submit_commands             1
+
+    contactgroups                   south
+
+    # User address6 to set the user's realm when he is imported in the backend
+    address6                        South
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/South/hosts.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/South/hosts.cfg
@@ -1,0 +1,11 @@
+define host{
+    use                     generic-host
+    contact_groups          admins
+    host_name               alignak-south-00
+    alias                   Alignak
+    display_name            Alignak (Demo)
+    address                 127.0.0.1
+
+    check_command           dummy_check!0
+    realm                   South
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/South/realm.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/South/realm.cfg
@@ -1,0 +1,5 @@
+define realm {
+    realm_name    South
+    alias         South country
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/realms/South/services.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/realms/South/services.cfg
@@ -1,0 +1,36 @@
+define service{
+  check_command                  _echo
+  host_name                      alignak-south-00
+  service_description            dummy_echo
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!0
+  host_name                      alignak-south-00
+  service_description            dummy_ok
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!1
+  host_name                      alignak-south-00
+  service_description            dummy_warning
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!2
+  host_name                      alignak-south-00
+  service_description            dummy_critical
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check
+  host_name                      alignak-south-00
+  service_description            dummy_unknown
+  use                            generic-service
+}
+define service{
+  check_command                  dummy_check!0!10
+  host_name                      alignak-south-00
+  service_description            dummy_timeout
+  use                            generic-service
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/resource.d/paths.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/resource.d/paths.cfg
@@ -1,0 +1,7 @@
+# Nagios legacy macros
+$USER1$=$NAGIOSPLUGINSDIR$
+$NAGIOSPLUGINSDIR$=/usr/lib/nagios/plugins
+
+#-- Location of the plugins for Alignak
+$PLUGINSDIR$=/tmp/var/libexec/alignak
+

--- a/test/cfg/alignak_full_run_realms/arbiter/templates/business-impacts.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/templates/business-impacts.cfg
@@ -1,0 +1,81 @@
+# Some business impact templates
+# ------------------------------
+# The default value for business impact is 2, meaning "normal".
+
+define host{
+    register                0
+    name                    no-importance
+    business_impact         0
+    # Disable notifications
+    notifications_enabled   0
+}
+
+define host{
+    register                0
+    name                    qualification
+    business_impact         1
+}
+
+define host{
+    register                0
+    name                    normal
+    business_impact         2
+}
+
+define host{
+    register                0
+    name                    production
+    business_impact         3
+}
+
+define host{
+    register                0
+    name                    important
+    business_impact         4
+}
+
+define host{
+    register                0
+    name                    top-for-business
+    business_impact         5
+}
+
+
+define service{
+    register                0
+    name                    no-importance
+    business_impact         0
+    # Disable notifications
+    notifications_enabled   0
+}
+
+define service{
+    register                0
+    name                    qualification
+    business_impact         1
+}
+
+define service{
+    register                0
+    name                    normal
+    business_impact         2
+}
+
+define service{
+    register                0
+    name                    production
+    business_impact         3
+}
+
+define service{
+    register                0
+    name                    important
+    business_impact         4
+}
+
+define service{
+    register                0
+    name                    top-for-business
+    business_impact         5
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/templates/generic-contact.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/templates/generic-contact.cfg
@@ -1,0 +1,11 @@
+# Contact definition
+# By default the contact will ask notification by mails
+define contact{
+        name                            generic-contact
+	host_notifications_enabled	1
+	service_notifications_enabled	1
+	email				alignak@localhost
+	can_submit_commands		1
+	notificationways        	email
+        register                        0
+	}

--- a/test/cfg/alignak_full_run_realms/arbiter/templates/generic-host.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/templates/generic-host.cfg
@@ -1,0 +1,42 @@
+# Generic host definition template - This is NOT a real host, just a template!
+# Most hosts should inherit from this one
+define host{
+    name                    generic-host
+
+    # Checking part
+    check_command           _internal_host_up
+    max_check_attempts      2
+    check_interval          5
+
+    # Check every time
+    active_checks_enabled   1
+    check_period            24x7
+
+    # Notification part
+    # One notification each day (1440 = 60min* 24h)
+    # every time, and for all 'errors'
+    # notify the admins contactgroups by default
+    contact_groups          admins,users
+    notification_interval   1440
+    notification_period     24x7
+    notification_options    d,u,r,f
+    notifications_enabled   1
+
+    # Advanced option
+    event_handler_enabled   0
+    flap_detection_enabled  1
+    process_perf_data       1
+    snapshot_enabled        0
+
+    # Maintenance / snapshot period
+    #maintenance_period      none
+    #snapshot_period         none
+
+    # Dispatching
+    #poller_tag          DMZ
+    #realm               All
+
+    # This to say that it's a template
+    register            0
+}
+

--- a/test/cfg/alignak_full_run_realms/arbiter/templates/generic-service.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/templates/generic-service.cfg
@@ -1,0 +1,20 @@
+# Generic service definition template - This is NOT a real service, just a template!
+define service{
+    name                            generic-service         ; The 'name' of this service template
+    active_checks_enabled           1                       ; Active service checks are enabled
+    passive_checks_enabled          1                       ; Passive service checks are enabled/accepted
+    notifications_enabled           1                       ; Service notifications are enabled
+    notification_interval           1440
+    notification_period             24x7
+    event_handler_enabled           0                       ; Service event handler is enabled
+    flap_detection_enabled          1                       ; Flap detection is enabled
+    process_perf_data               1                       ; Process performance data
+    is_volatile                     0                       ; The service is not volatile
+    check_period                    24x7                    ; The service can be checked at any time of the day
+    max_check_attempts              3                       ; Re-check the service up to 3 times in order to determine its final (hard) state
+    check_interval                  1                       ; Check the service every 1 minutes under normal conditions
+    retry_interval                  2                       ; Re-check the service every two minutes until a hard state can be determined
+    notification_options            w,u,c,r                 ; Send notifications about warning, unknown, critical, and recovery events
+    contact_groups                  admins,users
+    register                        0                       ; DONT REGISTER THIS DEFINITION - ITS NOT A REAL SERVICE, JUST A TEMPLATE
+}

--- a/test/cfg/alignak_full_run_realms/arbiter/templates/time_templates.cfg
+++ b/test/cfg/alignak_full_run_realms/arbiter/templates/time_templates.cfg
@@ -1,0 +1,231 @@
+##############################################################################
+##############################################################################
+#                                                                            
+# Different Time Check Interval Services
+#                                                                            
+##############################################################################
+##############################################################################
+
+##############################################################################
+# Purpose of time templates :
+# Simply define checks behavior of services with time template to avoid
+# false alerts.
+# There are three time template type : short, medium, long
+# - short means that it will be no retry check for service to be in hard state
+# - medium let a time period in soft state for service that can have peak load
+# - long let a greater time period in soft state, meant to service where
+# great variation and long charge time period are usual.
+##############################################################################
+
+# Check every 5min with immediate hard state
+define service{
+        name                            5min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           5
+        retry_interval                  2
+        register                        0
+}
+
+# Check every 5min with hard state 3min after first non-OK detection
+define service{
+        name                            5min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           5
+        retry_interval                  3
+        register                        0
+}
+
+# Check every 5min with hard state after 30min
+define service{
+        name                            5min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           5
+        retry_interval                  5
+        register                        0
+}
+
+# Check every 10min with immediate hard state
+define service{
+        name                            10min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           10
+        retry_interval                  5
+        register                        0
+}
+
+# Check every 10min with hard state 10min after first non-OK detection
+define service{
+        name                            10min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           10
+        retry_interval                  10
+        register                        0
+}
+
+# Check every 10min with hard state after 1hour
+define service{
+        name                            10min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           10
+        retry_interval                  10
+        register                        0
+}
+
+# Check every 20min with immediate hard state
+define service{
+        name                            20min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           20 
+        retry_interval                  1
+        register                        0
+}
+
+# Check every 20min with hard state 20min after first non-OK detection
+define service{
+        name                            20min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           20 
+        retry_interval                  20
+        register                        0
+}
+
+# Check every 20min with hard state after 2hours
+define service{
+        name                            20min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           20 
+        retry_interval                  20
+        register                        0
+}
+
+# Check every 30min with immediate hard state
+define service{
+        name                            30min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           30
+        retry_interval                  15
+        register                        0
+}
+
+# Check every 30min with hard state 30min after first non-OK detection
+define service{
+        name                            30min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           30
+        retry_interval                  30
+        register                        0
+}
+
+# Check every 30min with hard state after 6hours
+define service{
+        name                            30min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           30
+        retry_interval                  30
+        register                        0
+}
+
+# Check every 1hour with immediate hard state
+define service{
+        name                            1hour_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           60
+        retry_interval                  20
+        register                        0
+
+}
+
+# Check every 1hour with hard state 1hour after first non-OK detection
+define service{
+        name                            1hour_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           60
+        retry_interval                  60
+        register                        0
+
+}
+
+# Check every 1hour with hard state after 6hours
+define service{
+        name                            1hour_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           60
+        retry_interval                  60
+        register                        0
+
+}
+
+# Check every 12hours with immediate hard state
+define service{
+        name                            12hours_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           720
+        retry_interval                  360
+        register                        0
+}
+
+# Check every 12hours with hard state 12hours after first non-OK detection
+define service{
+        name                            12hours_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           720
+        retry_interval                  720
+        register                        0
+}
+
+# Check every 12hours with hard state after 3days
+define service{
+        name                            12hours_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           720
+        retry_interval                  720
+        register                        0
+}
+
+# Check every weeks with immediate hard state
+define service{
+        name                            1week_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           10080
+        retry_interval                  10
+        register                        0
+}
+
+# Check every weeks with hard state 1 week after first non-OK detection
+define service{
+        name                            1week_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           10080
+        retry_interval                  10080
+        register                        0
+}
+
+# Check every weeks with hard state after 4 weeks
+define service{
+        name                            1week_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           10080
+        retry_interval                  10080
+        register                        0
+}

--- a/test/cfg/alignak_full_run_realms/daemons/arbiter.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/arbiter.ini
@@ -1,0 +1,47 @@
+[daemon]
+
+#-- Path Configuration
+# paths variables values, if not absolute paths, they are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+etcdir=/tmp/etc/alignak
+
+# The daemon will chdir into the directory workdir when launched
+# It will create its pid file in the working dir
+pidfile=%(workdir)s/arbiter.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7770
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# Paths for certificates use the 'etcdir' variable
+#ca_cert=%(etcdir)s/certs/ca.pem
+#server_cert=%(etcdir)s/certs/server.csr
+#server_key=%(etcdir)s/certs/server.key
+#server_dh=%(etcdir)s/certs/server.pem
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=%(logdir)s/arbiter.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/broker-north.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/broker-north.ini
@@ -1,0 +1,50 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+
+pidfile=/tmp/broker-north.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17772
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/tmp/broker-north.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO
+
+#-- External modules watchdog --
+# If a module got a brok queue() higher than this value, it will be
+# killed and restart. Put to 0 to disable it
+max_queue_size=100000
+

--- a/test/cfg/alignak_full_run_realms/daemons/broker-south.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/broker-south.ini
@@ -1,0 +1,50 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+
+pidfile=/tmp/broker-south.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=27772
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/tmp/broker-south.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO
+
+#-- External modules watchdog --
+# If a module got a brok queue() higher than this value, it will be
+# killed and restart. Put to 0 to disable it
+max_queue_size=100000
+

--- a/test/cfg/alignak_full_run_realms/daemons/broker.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/broker.ini
@@ -1,0 +1,52 @@
+[daemon]
+
+#-- Path Configuration
+# paths variables values, if not absolute paths, they are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+etcdir=/tmp/etc/alignak
+
+# The daemon will chdir into the directory workdir when launched
+# It will create its pid file in the working dir
+pidfile=%(workdir)s/broker.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7772
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# Paths for certificates use the 'etcdir' variable
+#ca_cert=%(etcdir)s/certs/ca.pem
+#server_cert=%(etcdir)s/certs/server.csr
+#server_key=%(etcdir)s/certs/server.key
+#server_dh=%(etcdir)s/certs/server.pem
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=%(logdir)s/broker.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO
+
+#-- External modules watchdog --
+# If a module got a brok queue() higher than this value, it will be
+# killed and restart. Put to 0 to disable it
+max_queue_size=100000

--- a/test/cfg/alignak_full_run_realms/daemons/poller-north.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/poller-north.ini
@@ -1,0 +1,44 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+
+pidfile=/tmp/poller-north.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17771
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/tmp/poller-north.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/poller-south.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/poller-south.ini
@@ -1,0 +1,45 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+
+pidfile=/tmp/poller-south.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=27771
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/tmp/poller-south.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO
+

--- a/test/cfg/alignak_full_run_realms/daemons/poller.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/poller.ini
@@ -1,0 +1,47 @@
+[daemon]
+
+#-- Path Configuration
+# paths variables values, if not absolute paths, they are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+etcdir=/tmp/etc/alignak
+
+# The daemon will chdir into the directory workdir when launched
+# It will create its pid file in the working dir
+pidfile=%(workdir)s/poller.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7771
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# Paths for certificates use the 'etcdir' variable
+#ca_cert=%(etcdir)s/certs/ca.pem
+#server_cert=%(etcdir)s/certs/server.csr
+#server_key=%(etcdir)s/certs/server.key
+#server_dh=%(etcdir)s/certs/server.pem
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=%(logdir)s/poller.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/reactionner.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/reactionner.ini
@@ -1,0 +1,47 @@
+[daemon]
+
+#-- Path Configuration
+# paths variables values, if not absolute paths, they are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+etcdir=/tmp/etc/alignak
+
+# The daemon will chdir into the directory workdir when launched
+# It will create its pid file in the working dir
+pidfile=%(workdir)s/reactionner.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7769
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# Paths for certificates use the 'etcdir' variable
+#ca_cert=%(etcdir)s/certs/ca.pem
+#server_cert=%(etcdir)s/certs/server.csr
+#server_key=%(etcdir)s/certs/server.key
+#server_dh=%(etcdir)s/certs/server.pem
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=%(logdir)s/reactionner.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/receiver-north.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/receiver-north.ini
@@ -1,0 +1,44 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+
+pidfile=/tmp/receiver-north.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17773
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/tmp/etc/alignak/certs/ca.pem
+#server_cert=/tmp/etc/alignak/certs/server.cert
+#server_key=/tmp/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/tmp/receiver-north.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/receiver.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/receiver.ini
@@ -1,0 +1,47 @@
+[daemon]
+
+#-- Path Configuration
+# paths variables values, if not absolute paths, they are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+etcdir=/tmp/etc/alignak
+
+# The daemon will chdir into the directory workdir when launched
+# It will create its pid file in the working dir
+pidfile=%(workdir)s/receiver.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7773
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# Paths for certificates use the 'etcdir' variable
+#ca_cert=%(etcdir)s/certs/ca.pem
+#server_cert=%(etcdir)s/certs/server.csr
+#server_key=%(etcdir)s/certs/server.key
+#server_dh=%(etcdir)s/certs/server.pem
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=%(logdir)s/receiver.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/scheduler-north.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/scheduler-north.ini
@@ -1,0 +1,48 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+
+pidfile=/tmp/scheduler-north.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17768
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+
+# To be changed, to match your real modules directory installation
+#modulesdir=modules
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/tmp/scheduler-north.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/scheduler-south.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/scheduler-south.ini
@@ -1,0 +1,48 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+
+pidfile=/tmp/scheduler-south.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=27768
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+
+# To be changed, to match your real modules directory installation
+#modulesdir=modules
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/tmp/scheduler-south.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/daemons/scheduler.ini
+++ b/test/cfg/alignak_full_run_realms/daemons/scheduler.ini
@@ -1,0 +1,51 @@
+[daemon]
+
+#-- Path Configuration
+# paths variables values, if not absolute paths, they are relative to workdir.
+# using default values for following config variables value:
+workdir=/tmp
+logdir=/tmp
+etcdir=/tmp/etc/alignak
+
+# The daemon will chdir into the directory workdir when launched
+# It will create its pid file in the working dir
+pidfile=%(workdir)s/scheduler.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7768
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+
+# To be changed, to match your real modules directory installation
+#modulesdir=modules
+
+#-- SSL configuration --
+use_ssl=0
+# Paths for certificates use the 'etcdir' variable
+#ca_cert=%(etcdir)s/certs/ca.pem
+#server_cert=%(etcdir)s/certs/server.csr
+#server_key=%(etcdir)s/certs/server.key
+#server_dh=%(etcdir)s/certs/server.pem
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=%(logdir)s/scheduler.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/cfg/alignak_full_run_realms/dummy_command.sh
+++ b/test/cfg/alignak_full_run_realms/dummy_command.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+echo "Hi, I'm the dummy check. | Hip=99% Hop=34mm"
+if [ -n "$2" ]; then
+  SLEEP=$2
+else
+  SLEEP=1
+fi
+sleep $SLEEP
+if [ -n "$1" ]; then
+    exit $1
+else
+    exit 3
+fi

--- a/test/test_actions.py
+++ b/test/test_actions.py
@@ -381,7 +381,7 @@ class TestAction(AlignakTest):
         self.wait_finished(a)
         assert 0 == a.exit_status
         assert 'done' == a.status
-        assert u"Wiadomo\u015b\u0107" == a.output.decode('utf8')
+        assert u"Wiadomo\u015b\u0107" == a.output
         assert "" == a.long_output
         assert "" == a.perf_data
 

--- a/test/test_launch_daemons.py
+++ b/test/test_launch_daemons.py
@@ -51,9 +51,6 @@ class DaemonsStartTest(AlignakTest):
             print("Problem on terminate and wait subproc %s: %s" % (name, err))
 
     def setUp(self):
-        # Set environment variable to ask code Coverage collection
-        os.environ['COVERAGE_PROCESS_START'] = '.coveragerc'
-
         self.procs = {}
 
     def tearDown(self):

--- a/test/test_launch_daemons_modules.py
+++ b/test/test_launch_daemons_modules.py
@@ -43,9 +43,6 @@ class LaunchDaemons(AlignakTest):
             print("Problem on terminate and wait subproc %s: %s" % (name, err))
 
     def setUp(self):
-        # Set environment variable to ask code Coverage collection
-        os.environ['COVERAGE_PROCESS_START'] = '.coveragerc'
-
         self.procs = {}
 
     def tearDown(self):

--- a/test/test_launch_daemons_realms_and_checks.py
+++ b/test/test_launch_daemons_realms_and_checks.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
+#
+# This file is part of Alignak.
+#
+# Alignak is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Alignak is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import sys
+import signal
+
+import subprocess
+from time import sleep
+import shutil
+
+from alignak_test import AlignakTest
+
+
+class TestLaunchDaemonsRealms(AlignakTest):
+    def _get_subproc_data(self, name):
+        try:
+            print("Polling %s" % name)
+            if self.procs[name].poll():
+                print("Killing %s..." % name)
+                os.kill(self.procs[name].pid, signal.SIGKILL)
+            print("%s terminated" % name)
+
+        except Exception as err:
+            print("Problem on terminate and wait subproc %s: %s" % (name, err))
+
+    def setUp(self):
+        self.procs = {}
+
+    def tearDown(self):
+        print("Test terminated!")
+
+    def run_and_check_alignak_daemons(self, runtime=10):
+        """ Run the Alignak daemons for a 3 realms configuration
+
+        Let the daemons run for the number of seconds defined in the runtime parameter
+
+        Check that the run daemons did not raised any ERROR log
+
+        :return: None
+        """
+        self.print_header()
+
+        # Load and test the configuration
+        self.setup_with_file('cfg/alignak_full_run_realms/alignak.cfg')
+        assert self.conf_is_correct
+
+        self.procs = {}
+        daemons_list = ['broker', 'broker-north', 'broker-south',
+                        'poller', 'poller-north', 'poller-south',
+                        'reactionner',
+                        'receiver', 'receiver-north',
+                        'scheduler', 'scheduler-north', 'scheduler-south',]
+
+        print("Cleaning pid and log files...")
+        for daemon in ['arbiter'] + daemons_list:
+            if os.path.exists('/tmp/%s.pid' % daemon):
+                os.remove('/tmp/%s.pid' % daemon)
+                print("- removed /tmp/%s.pid" % daemon)
+            if os.path.exists('/tmp/%s.log' % daemon):
+                os.remove('/tmp/%s.log' % daemon)
+                print("- removed /tmp/%s.log" % daemon)
+
+        shutil.copy('./cfg/alignak_full_run_realms/dummy_command.sh', '/tmp/dummy_command.sh')
+
+        print("Launching the daemons...")
+        for daemon in daemons_list:
+            alignak_daemon = "../alignak/bin/alignak_%s.py" % daemon.split('-')[0]
+
+            args = [alignak_daemon, "-c", "./cfg/alignak_full_run_realms/daemons/%s.ini" % daemon]
+            self.procs[daemon] = \
+                subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            print("- %s launched (pid=%d)" % (daemon, self.procs[daemon].pid))
+
+        sleep(1)
+
+        print("Testing daemons start")
+        for name, proc in self.procs.items():
+            ret = proc.poll()
+            if ret is not None:
+                print("*** %s exited on start!" % (name))
+                for line in iter(proc.stdout.readline, b''):
+                    print(">>> " + line.rstrip())
+                for line in iter(proc.stderr.readline, b''):
+                    print(">>> " + line.rstrip())
+            assert ret is None, "Daemon %s not started!" % name
+            print("- %s running (pid=%d)" % (name, self.procs[daemon].pid))
+
+        # Let the daemons start ...
+        sleep(1)
+
+        print("Launching arbiter...")
+        args = ["../alignak/bin/alignak_arbiter.py",
+                "-c", "cfg/alignak_full_run_realms/daemons/arbiter.ini",
+                "-a", "cfg/alignak_full_run_realms/alignak.cfg"]
+        self.procs['arbiter'] = \
+            subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print("- %s launched (pid=%d)" % ('arbiter', self.procs['arbiter'].pid))
+
+        sleep(5)
+
+        name = 'arbiter'
+        print("Testing Arbiter start %s" % name)
+        ret = self.procs[name].poll()
+        if ret is not None:
+            print("*** %s exited on start!" % (name))
+            for line in iter(self.procs[name].stdout.readline, b''):
+                print(">>> " + line.rstrip())
+            for line in iter(self.procs[name].stderr.readline, b''):
+                print(">>> " + line.rstrip())
+        assert ret is None, "Daemon %s not started!" % name
+        print("- %s running (pid=%d)" % (name, self.procs[name].pid))
+
+        # Let the arbiter build and dispatch its configuration
+        # Let the schedulers get their configuration and run the first checks
+        sleep(runtime)
+
+        print("Get information from log files...")
+        nb_errors = 0
+        for daemon in ['arbiter'] + daemons_list:
+            assert os.path.exists('/tmp/%s.log' % daemon), '/tmp/%s.log does not exist!' % daemon
+            daemon_errors = False
+            print("-----\n%s log file\n-----\n" % daemon)
+            with open('/tmp/%s.log' % daemon) as f:
+                for line in f:
+                    if 'WARNING' in line or daemon_errors:
+                        print(line)
+                    if 'ERROR' in line or 'CRITICAL' in line:
+                        if not daemon_errors:
+                            print(line[:-1])
+                        daemon_errors = True
+                        nb_errors += 1
+        assert nb_errors == 0, "Error logs raised!"
+        print("No error logs raised when daemons loaded the modules")
+
+        print("Stopping the daemons...")
+        for name, proc in self.procs.items():
+            print("Asking %s to end..." % name)
+            os.kill(self.procs[name].pid, signal.SIGTERM)
+
+    def test_daemons_realms(self):
+        """ Running the Alignak daemons for a 3 realms configuration
+
+        :return: None
+        """
+        self.print_header()
+
+        self.run_and_check_alignak_daemons()
+
+    def test_correct_checks_launch_and_result(self):
+        """ Run the Alignak daemons and check the correct checks result
+
+        :return: None
+        """
+        self.print_header()
+
+        # Set an environment variable to activate the logging of checks execution
+        # With this the pollers/schedulers will raise WARNING logs about the checks execution
+        os.environ['TEST_LOG_ACTIONS'] = 'Yes'
+
+        # Run deamons for 2 minutes
+        self.run_and_check_alignak_daemons(120)
+
+        # Expected WARNING logs from the daemons
+        initgroups = 'initgroups'
+        if sys.version_info < (2, 7):
+            initgroups = 'setgroups'
+        expected_logs = {
+            'poller': [
+                "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 0' exited with return code 0",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 0': 0, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh' exited with return code 3",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh': 3, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 1'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 1' exited with return code 1",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 1': 1, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 2'",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0 10'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 2' exited with return code 2",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 2': 2, Hi, I'm the dummy check.",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 0 10' exited on timeout (5 s)",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh' exited with return code 3",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh': 3, Hi, I'm the dummy check.",
+            ],
+            'poller-north': [
+                "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 0' exited with return code 0",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 0': 0, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 1'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 1' exited with return code 1",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 1': 1, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 2'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 2' exited with return code 2",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 2': 2, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0 10'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 0 10' exited on timeout (5 s)",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh' exited with return code 3",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh': 3, Hi, I'm the dummy check.",
+            ],
+            'poller-south': [
+                "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh' exited with return code 3",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh': 3, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 1'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 1' exited with return code 1",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 1': 1, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 0' exited with return code 0",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 0': 0, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 2'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 2' exited with return code 2",
+                "[alignak.action] Check result for '/tmp/dummy_command.sh 2': 2, Hi, I'm the dummy check.",
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0 10'",
+                "[alignak.action] Check for '/tmp/dummy_command.sh 0 10' exited on timeout (5 s)",
+            ],
+            'scheduler': [
+                "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
+                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-all-00/dummy_timeout'), check status code: 2, execution time: 5 seconds"
+            ],
+            'scheduler-north': [
+                "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
+                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-north-00/dummy_timeout'), check status code: 2, execution time: 5 seconds"
+            ],
+            'scheduler-south': [
+                "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
+                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-south-00/dummy_timeout'), check status code: 2, execution time: 5 seconds"
+            ]
+        }
+        logs = {}
+
+        for name in ['poller', 'poller-north', 'poller-south',
+                     'scheduler', 'scheduler-north', 'scheduler-south']:
+            assert os.path.exists('/tmp/%s.log' % name), '/tmp/%s.log does not exist!' % name
+            logs[name] = []
+            print("-----\n%s log file\n" % name)
+            with open('/tmp/%s.log' % name) as f:
+                for line in f:
+                    # Catches only the WARNING logs
+                    if 'WARNING' in line:
+                        # ansi_escape.sub('', line)
+                        line = line.split('WARNING: ')
+                        line = line[1]
+                        line = line.strip()
+                        # Remove the leading ": "
+                        logs[name].append(line)
+                        print(">>> " + line)
+
+            for log in expected_logs[name]:
+                assert log in logs[name]
+


### PR DESCRIPTION
This PR includes the following:
- add a test that runs several daemons dispatched in 3 realms, a total of 13 daemons is launched
- launch real checks from the pollers
- check that the check launch and result are correctly managed
- remove no more useful COVERAGE environment variable

-----
Note that to allow thoses tests, an anvironment variable is defined to raise WARNING logs for the actions execution and execution result. This will be documented in the Alignak doc as a developer tip :)