### PR TITLE
Fix #615: fix command_call serialization in notifications

### DIFF
--- a/alignak/notification.py
+++ b/alignak/notification.py
@@ -188,5 +188,7 @@ class Notification(Action):  # pylint: disable=R0902
         res = super(Notification, self).serialize()
 
         if res['command_call'] is not None:
-            res['command_call'] = res['command_call'].serialize()
+            if not isinstance(res['command_call'], str) and \
+                    not isinstance(res['command_call'], dict):
+                res['command_call'] = res['command_call'].serialize()
         return res


### PR DESCRIPTION
Could not reproduce this behavior with unit tests, I tested this modification on my running test server