### PR TITLE
Fix #617: remove exit_status initialization

### DIFF
--- a/alignak/action.py
+++ b/alignak/action.py
@@ -271,7 +271,7 @@ class ActionBase(AlignakObject):
                      self.command, self.exit_status, self.output)
         if self.log_actions:
             logger.info("Check result for '%s': %d, %s",
-                           self.command, self.exit_status, self.output)
+                        self.command, self.exit_status, self.output)
 
     def check_finished(self, max_plugins_output_length):
         """Handle action if it is finished (get stdout, stderr, exit code...)
@@ -312,7 +312,7 @@ class ActionBase(AlignakObject):
                 self.s_time = n_child_stime - child_stime
                 if self.log_actions:
                     logger.info("Check for '%s' exited on timeout (%d s)",
-                                   self.command, self.timeout)
+                                self.command, self.timeout)
                 return
             return
 
@@ -330,7 +330,7 @@ class ActionBase(AlignakObject):
         self.exit_status = self.process.returncode
         if self.log_actions:
             logger.info("Check for '%s' exited with return code %d",
-                           self.command, self.exit_status)
+                        self.command, self.exit_status)
 
         # we should not keep the process now
         del self.process

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -213,7 +213,7 @@ class ActionBase(AlignakObject):
 
         logger.debug("Launch command: '%s'", self.command)
         if self.log_actions:
-            logger.warning("Launch command: '%s'", self.command)
+            logger.info("Launch command: '%s'", self.command)
 
         return self.execute__()  # OS specific part
 
@@ -270,7 +270,7 @@ class ActionBase(AlignakObject):
         logger.debug("Command result for '%s': %d, %s",
                      self.command, self.exit_status, self.output)
         if self.log_actions:
-            logger.warning("Check result for '%s': %d, %s",
+            logger.info("Check result for '%s': %d, %s",
                            self.command, self.exit_status, self.output)
 
     def check_finished(self, max_plugins_output_length):
@@ -311,7 +311,7 @@ class ActionBase(AlignakObject):
                 self.u_time = n_child_utime - child_utime
                 self.s_time = n_child_stime - child_stime
                 if self.log_actions:
-                    logger.warning("Check for '%s' exited on timeout (%d s)",
+                    logger.info("Check for '%s' exited on timeout (%d s)",
                                    self.command, self.timeout)
                 return
             return
@@ -329,7 +329,7 @@ class ActionBase(AlignakObject):
 
         self.exit_status = self.process.returncode
         if self.log_actions:
-            logger.warning("Check for '%s' exited with return code %d",
+            logger.info("Check for '%s' exited with return code %d",
                            self.command, self.exit_status)
 
         # we should not keep the process now

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -136,7 +136,6 @@ class ActionBase(AlignakObject):
     def __init__(self, params=None, parsing=True):
         super(ActionBase, self).__init__(params, parsing=parsing)
         self.creation_time = time.time()
-        self.exit_status = 3
         self.fill_default()
         self.log_actions = 'TEST_LOG_ACTIONS' in os.environ
 

--- a/alignak/action.py
+++ b/alignak/action.py
@@ -112,32 +112,58 @@ class ActionBase(AlignakObject):
     process = None
 
     properties = {
-        'is_a':             StringProp(default=''),
-        'type':             StringProp(default=''),
-        'creation_time':       FloatProp(default=0.0),
-        '_in_timeout':      BoolProp(default=False),
-        'status':           StringProp(default='scheduled'),
-        'exit_status':      IntegerProp(default=3),
-        'output':           StringProp(default='', fill_brok=['full_status']),
-        't_to_go':          FloatProp(default=0.0),
-        'check_time':       IntegerProp(default=0),
-        'execution_time':   FloatProp(default=0.0),
-        'u_time':           FloatProp(default=0.0),
-        's_time':           FloatProp(default=0.0),
-        'reactionner_tag':  StringProp(default='None'),
-        'env':              DictProp(default={}),
-        'module_type':      StringProp(default='fork', fill_brok=['full_status']),
-        'worker':           StringProp(default='none'),
-        'command':          StringProp(),
-        'timeout':          IntegerProp(default=10),
-        'ref':              StringProp(default=''),
+        'is_a':
+            StringProp(default=''),
+        'type':
+            StringProp(default=''),
+        'creation_time':
+            FloatProp(default=0.0),
+        '_in_timeout':
+            BoolProp(default=False),
+        'status':
+            StringProp(default='scheduled'),
+        'exit_status':
+            IntegerProp(default=3),
+        'output':
+            StringProp(default='', fill_brok=['full_status']),
+        't_to_go':
+            FloatProp(default=0.0),
+        'check_time':
+            IntegerProp(default=0),
+        'execution_time':
+            FloatProp(default=0.0),
+        'u_time':
+            FloatProp(default=0.0),
+        's_time':
+            FloatProp(default=0.0),
+        'reactionner_tag':
+            StringProp(default='None'),
+        'env':
+            DictProp(default={}),
+        'module_type':
+            StringProp(default='fork', fill_brok=['full_status']),
+        'worker':
+            StringProp(default='none'),
+        'command':
+            StringProp(),
+        'timeout':
+            IntegerProp(default=10),
+        'ref':
+            StringProp(default=''),
     }
 
     def __init__(self, params=None, parsing=True):
         super(ActionBase, self).__init__(params, parsing=parsing)
-        self.creation_time = time.time()
+
+        # Set a creation time only if not provided
+        if not params or 'creation_time' not in params:
+            self.creation_time = time.time()
+        # Set actions log only if not provided
+        if not params or 'log_actions' not in params:
+            self.log_actions = 'TEST_LOG_ACTIONS' in os.environ
+
+        # Fill default parameters
         self.fill_default()
-        self.log_actions = 'TEST_LOG_ACTIONS' in os.environ
 
     def set_type_active(self):
         """Dummy function, only useful for checks"""

--- a/alignak/check.py
+++ b/alignak/check.py
@@ -71,17 +71,28 @@ class Check(Action):  # pylint: disable=R0902
 
     properties = Action.properties.copy()
     properties.update({
-        'is_a':             StringProp(default='check'),
-        'state':            IntegerProp(default=0),
-        'long_output':      StringProp(default=''),
-        'depend_on':        ListProp(default=[]),
-        'depend_on_me':     ListProp(default=[], split_on_coma=False),
-        'perf_data':        StringProp(default=''),
-        'check_type':       IntegerProp(default=0),
-        'poller_tag':       StringProp(default='None'),
-        'internal':         BoolProp(default=False),
-        'from_trigger':     BoolProp(default=False),
-        'dependency_check': BoolProp(default=False),
+        'is_a':
+            StringProp(default='check'),
+        'state':
+            IntegerProp(default=0),
+        'long_output':
+            StringProp(default=''),
+        'depend_on':
+            ListProp(default=[]),
+        'depend_on_me':
+            ListProp(default=[], split_on_coma=False),
+        'perf_data':
+            StringProp(default=''),
+        'check_type':
+            IntegerProp(default=0),
+        'poller_tag':
+            StringProp(default='None'),
+        'internal':
+            BoolProp(default=False),
+        'from_trigger':
+            BoolProp(default=False),
+        'dependency_check':
+            BoolProp(default=False),
     })
 
     def get_return_from(self, check):

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -80,11 +80,11 @@ class Dispatcher:
         self.arbiter = arbiter
         # Pointer to the whole conf
         self.conf = conf
-        logger.warning("Dispatcher __init__: %s / %s", self.arbiter, self.conf)
+        logger.debug("Dispatcher __init__: %s / %s", self.arbiter, self.conf)
         if hasattr(self.conf, 'confs'):
-            logger.warning("Dispatch conf confs: %s", self.conf.confs)
+            logger.debug("Dispatch conf confs: %s", self.conf.confs)
         else:
-            logger.warning("Dispatch conf has no confs")
+            logger.debug("Dispatch conf has no confs")
 
         self.realms = conf.realms
         # Direct pointer to important elements for us

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -80,6 +80,12 @@ class Dispatcher:
         self.arbiter = arbiter
         # Pointer to the whole conf
         self.conf = conf
+        logger.warning("Dispatcher __init__: %s / %s", self.arbiter, self.conf)
+        if hasattr(self.conf, 'confs'):
+            logger.warning("Dispatch conf confs: %s", self.conf.confs)
+        else:
+            logger.warning("Dispatch conf has no confs")
+
         self.realms = conf.realms
         # Direct pointer to important elements for us
 

--- a/alignak/eventhandler.py
+++ b/alignak/eventhandler.py
@@ -68,11 +68,16 @@ class EventHandler(Action):
 
     properties = Action.properties.copy()
     properties.update({
-        'is_a':           StringProp(default='eventhandler'),
-        'long_output':    StringProp(default=''),
-        'perf_data':      StringProp(default=''),
-        'sched_id':       IntegerProp(default=0),
-        'is_snapshot':    BoolProp(default=False),
+        'is_a':
+            StringProp(default='eventhandler'),
+        'long_output':
+            StringProp(default=''),
+        'perf_data':
+            StringProp(default=''),
+        'sched_id':
+            IntegerProp(default=0),
+        'is_snapshot':
+            BoolProp(default=False),
     })
 
     def __init__(self, params=None, parsing=True):

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -1547,6 +1547,9 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         ok_up = self.__class__.ok_up  # OK for service, UP for host
 
         # ============ MANAGE THE CHECK ============ #
+        if 'TEST_LOG_ACTIONS' in os.environ:
+            logger.warning("Got check result: %d for '%s'",
+                           chk.exit_status, self.get_full_name())
 
         # Not OK, waitconsume and have dependencies, put this check in waitdep, create if
         # necessary the check of dependent items and nothing else ;)

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -1549,7 +1549,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         # ============ MANAGE THE CHECK ============ #
         if 'TEST_LOG_ACTIONS' in os.environ:
             logger.info("Got check result: %d for '%s'",
-                           chk.exit_status, self.get_full_name())
+                        chk.exit_status, self.get_full_name())
 
         # Not OK, waitconsume and have dependencies, put this check in waitdep, create if
         # necessary the check of dependent items and nothing else ;)
@@ -2619,7 +2619,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
                                                              macromodulations, timeperiods)
                 if 'TEST_LOG_ACTIONS' in os.environ:
                     logger.info("Resolved BR for '%s', output: %s",
-                                   self.get_full_name(), check.output)
+                                self.get_full_name(), check.output)
             except Exception, err:  # pylint: disable=W0703
                 # Notifies the error, and return an UNKNOWN state.
                 check.output = "Error while re-evaluating business rule: %s" % err
@@ -2640,7 +2640,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
             check.output = self.output
             if 'TEST_LOG_ACTIONS' in os.environ:
                 logger.info("Echo the current state (%d) for %s ",
-                               self.state, self.get_full_name())
+                            self.state, self.get_full_name())
         check.long_output = check.output
         check.check_time = time.time()
         check.exit_status = state

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -1548,7 +1548,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
 
         # ============ MANAGE THE CHECK ============ #
         if 'TEST_LOG_ACTIONS' in os.environ:
-            logger.warning("Got check result: %d for '%s'",
+            logger.info("Got check result: %d for '%s'",
                            chk.exit_status, self.get_full_name())
 
         # Not OK, waitconsume and have dependencies, put this check in waitdep, create if
@@ -2618,7 +2618,7 @@ class SchedulingItem(Item):  # pylint: disable=R0902
                 check.output = self.get_business_rule_output(hosts, services,
                                                              macromodulations, timeperiods)
                 if 'TEST_LOG_ACTIONS' in os.environ:
-                    logger.warning("Resolved BR for '%s', output: %s",
+                    logger.info("Resolved BR for '%s', output: %s",
                                    self.get_full_name(), check.output)
             except Exception, err:  # pylint: disable=W0703
                 # Notifies the error, and return an UNKNOWN state.
@@ -2632,14 +2632,14 @@ class SchedulingItem(Item):  # pylint: disable=R0902
             check.execution_time = 0
             check.output = 'Host assumed to be UP'
             if 'TEST_LOG_ACTIONS' in os.environ:
-                logger.warning("Set host %s as UP (internal check)", self.get_full_name())
+                logger.info("Set host %s as UP (internal check)", self.get_full_name())
         # Echo is just putting the same state again
         elif check.command == '_echo':
             state = self.state
             check.execution_time = 0
             check.output = self.output
             if 'TEST_LOG_ACTIONS' in os.environ:
-                logger.warning("Echo the current state (%d) for %s ",
+                logger.info("Echo the current state (%d) for %s ",
                                self.state, self.get_full_name())
         check.long_output = check.output
         check.check_time = time.time()

--- a/test/test_launch_daemons_realms_and_checks.py
+++ b/test/test_launch_daemons_realms_and_checks.py
@@ -186,20 +186,26 @@ class TestLaunchDaemonsRealms(AlignakTest):
         expected_logs = {
             'poller': [
                 "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
+                # Check Ok
                 "[alignak.action] Launch command: '/tmp/dummy_command.sh 0'",
                 "[alignak.action] Check for '/tmp/dummy_command.sh 0' exited with return code 0",
                 "[alignak.action] Check result for '/tmp/dummy_command.sh 0': 0, Hi, I'm the dummy check.",
+                # Check unknown
                 "[alignak.action] Launch command: '/tmp/dummy_command.sh'",
                 "[alignak.action] Check for '/tmp/dummy_command.sh' exited with return code 3",
                 "[alignak.action] Check result for '/tmp/dummy_command.sh': 3, Hi, I'm the dummy check.",
+                # Check warning
                 "[alignak.action] Launch command: '/tmp/dummy_command.sh 1'",
                 "[alignak.action] Check for '/tmp/dummy_command.sh 1' exited with return code 1",
                 "[alignak.action] Check result for '/tmp/dummy_command.sh 1': 1, Hi, I'm the dummy check.",
+                # Check critical
                 "[alignak.action] Launch command: '/tmp/dummy_command.sh 2'",
-                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0 10'",
                 "[alignak.action] Check for '/tmp/dummy_command.sh 2' exited with return code 2",
                 "[alignak.action] Check result for '/tmp/dummy_command.sh 2': 2, Hi, I'm the dummy check.",
+                # Check timeout
+                "[alignak.action] Launch command: '/tmp/dummy_command.sh 0 10'",
                 "[alignak.action] Check for '/tmp/dummy_command.sh 0 10' exited on timeout (5 s)",
+                # Check unknown
                 "[alignak.action] Launch command: '/tmp/dummy_command.sh'",
                 "[alignak.action] Check for '/tmp/dummy_command.sh' exited with return code 3",
                 "[alignak.action] Check result for '/tmp/dummy_command.sh': 3, Hi, I'm the dummy check.",
@@ -239,16 +245,40 @@ class TestLaunchDaemonsRealms(AlignakTest):
                 "[alignak.action] Check for '/tmp/dummy_command.sh 0 10' exited on timeout (5 s)",
             ],
             'scheduler': [
+                # Internal host check
+                # "[alignak.objects.schedulingitem] Set host localhost as UP (internal check)",
+                # "[alignak.objects.schedulingitem] Got check result: 0 for 'localhost'",
                 "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
-                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-all-00/dummy_timeout'), check status code: 2, execution time: 5 seconds"
+                # Timed out check
+                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-all-00/dummy_timeout'), check status code: 2, execution time: 5 seconds",
+                # Check ok
+                "[alignak.objects.schedulingitem] Got check result: 0 for 'alignak-all-00/dummy_ok'",
+                # Check warning
+                "[alignak.objects.schedulingitem] Got check result: 1 for 'alignak-all-00/dummy_warning'",
+                # Check critical
+                "[alignak.objects.schedulingitem] Got check result: 2 for 'alignak-all-00/dummy_critical'",
+                # Check unknown
+                "[alignak.objects.schedulingitem] Got check result: 3 for 'alignak-all-00/dummy_unknown'",
+                # Check time
+                "[alignak.objects.schedulingitem] Got check result: 2 for 'alignak-all-00/dummy_timeout'",
             ],
             'scheduler-north': [
                 "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
-                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-north-00/dummy_timeout'), check status code: 2, execution time: 5 seconds"
+                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-north-00/dummy_timeout'), check status code: 2, execution time: 5 seconds",
+                "[alignak.objects.schedulingitem] Got check result: 0 for 'alignak-north-00/dummy_ok'",
+                "[alignak.objects.schedulingitem] Got check result: 1 for 'alignak-north-00/dummy_warning'",
+                "[alignak.objects.schedulingitem] Got check result: 2 for 'alignak-north-00/dummy_critical'",
+                "[alignak.objects.schedulingitem] Got check result: 3 for 'alignak-north-00/dummy_unknown'",
+                "[alignak.objects.schedulingitem] Got check result: 2 for 'alignak-north-00/dummy_timeout'",
             ],
             'scheduler-south': [
                 "[alignak.daemon] Cannot call the additional groups setting with %s (Operation not permitted)" % initgroups,
-                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-south-00/dummy_timeout'), check status code: 2, execution time: 5 seconds"
+                "[alignak.scheduler] Timeout raised for '/tmp/dummy_command.sh 0 10' (check command for the service 'alignak-south-00/dummy_timeout'), check status code: 2, execution time: 5 seconds",
+                "[alignak.objects.schedulingitem] Got check result: 0 for 'alignak-south-00/dummy_ok'",
+                "[alignak.objects.schedulingitem] Got check result: 1 for 'alignak-south-00/dummy_warning'",
+                "[alignak.objects.schedulingitem] Got check result: 2 for 'alignak-south-00/dummy_critical'",
+                "[alignak.objects.schedulingitem] Got check result: 3 for 'alignak-south-00/dummy_unknown'",
+                "[alignak.objects.schedulingitem] Got check result: 2 for 'alignak-south-00/dummy_timeout'",
             ]
         }
         logs = {}


### PR DESCRIPTION
When actions are sent to worker and initialized in the worker, the `exit_status` must not be set with `self.exit_status = 3` because it will be set with the value contained in the params of the function. trying to initialize this field breaks the normal initialization and the action always returns an `exit_status` which is 3.