### PR TITLE
Daemons API serialization error log (API get_all_states)

### DIFF
--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -162,15 +162,15 @@ class ArbiterInterface(GenericInterface):
                     for prop in props:
                         if not hasattr(daemon, prop):
                             continue
-                        val = getattr(daemon, prop)
                         if prop in ["realms", "conf", "con", "tags"]:
                             continue
+                        val = getattr(daemon, prop)
                         # give a try to a json able object
                         try:
                             json.dumps(val)
                             env[prop] = val
                         except TypeError as exp:
-                            logger.error('%s: %s', prop, str(exp))
+                            logger.warning('get_all_states, %s: %s', prop, str(exp))
                 lst.append(env)
         return res
 

--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -70,10 +70,10 @@ class ArbiterInterface(GenericInterface):
 
         :return: None
         """
-        # If I'm the master, ignore the command
+        # If I'm the master, ignore the command and raise a log
         if self.app.is_master:
-            logger.debug("Received message to not run. "
-                         "I am the Master, ignore and continue to run.")
+            logger.warning("Received message to not run. "
+                           "I am the Master, ignore and continue to run.")
         # Else, I'm just a spare, so I listen to my master
         else:
             logger.debug("Received message to not run. I am the spare, stopping.")
@@ -163,14 +163,14 @@ class ArbiterInterface(GenericInterface):
                         if not hasattr(daemon, prop):
                             continue
                         val = getattr(daemon, prop)
-                        if prop == "realm":
+                        if prop in ["realms", "conf", "con", "tags"]:
                             continue
                         # give a try to a json able object
                         try:
                             json.dumps(val)
                             env[prop] = val
-                        except TypeError, exp:
-                            logger.debug('%s', exp)
+                        except TypeError as exp:
+                            logger.error('%s: %s', prop, str(exp))
                 lst.append(env)
         return res
 

--- a/alignak/http/generic_interface.py
+++ b/alignak/http/generic_interface.py
@@ -108,16 +108,22 @@ class GenericInterface(object):
         return self.app.cur_conf is not None
 
     @cherrypy.expose
+    @cherrypy.tools.json_in()
     @cherrypy.tools.json_out()
-    def set_log_level(self, loglevel):  # pylint: disable=R0201
+    def set_log_level(self, loglevel=None):  # pylint: disable=R0201
         """Set the current log level in [NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL, UNKNOWN]
 
         :param loglevel: a value in one of the above
         :type loglevel: str
         :return: None
         """
+        if loglevel is None:
+            parameters = cherrypy.request.json
+            loglevel = parameters['loglevel']
         alignak_logger = logging.getLogger("alignak")
-        return alignak_logger.setLevel(loglevel)
+        alignak_logger.setLevel(loglevel)
+        return loglevel
+    set_log_level.method = 'post'
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
@@ -127,12 +133,13 @@ class GenericInterface(object):
         :return: current log level
         :rtype: str
         """
+        alignak_logger = logging.getLogger("alignak")
         return {logging.NOTSET: 'NOTSET',
                 logging.DEBUG: 'DEBUG',
                 logging.INFO: 'INFO',
                 logging.WARNING: 'WARNING',
                 logging.ERROR: 'ERROR',
-                logging.CRITICAL: 'CRITICAL'}.get(logger.level, 'UNKNOWN')
+                logging.CRITICAL: 'CRITICAL'}.get(alignak_logger.getEffectiveLevel(), 'UNKNOWN')
 
     @cherrypy.expose
     @cherrypy.tools.json_out()

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2661,11 +2661,20 @@ class Config(Item):  # pylint: disable=R0904,R0902
                          "resultmodulations",
                          "businessimpactmodulations",
                          "escalations",
+                         "arbiters",
+                         "brokers",
+                         "pollers",
+                         "reactionners",
+                         "receivers",
                          "schedulers",
                          "realms",
                          ):
             try:
                 objs = [jsonify_r(i) for i in getattr(self, category)]
+            except TypeError:
+                logger.warning("Dumping configuration, '%s' not present in the configuration",
+                               category)
+                continue
             except AttributeError:
                 logger.warning("Dumping configuration, '%s' not present in the configuration",
                                category)

--- a/test/test_launch_daemons.py
+++ b/test/test_launch_daemons.py
@@ -20,6 +20,7 @@
 #
 
 import os
+import sys
 import time
 import signal
 import json
@@ -451,7 +452,10 @@ class DaemonsStartTest(AlignakTest):
         print("Testing get_log_level")
         for name, port in satellite_map.items():
             raw_data = req.get("%s://localhost:%s/get_log_level" % (http, port), verify=False)
-            assert raw_data.json() == 'DEBUG'
+            if sys.version_info < (2, 7):
+                assert raw_data.json() == 'UNKNOWN' # Cannot get log level with python 2.6
+            else:
+                assert raw_data.json() == 'DEBUG'
 
         print("Testing get_all_states")
         raw_data = req.get("%s://localhost:%s/get_all_states" % (http, satellite_map['arbiter']), verify=False)

--- a/test/test_launch_daemons.py
+++ b/test/test_launch_daemons.py
@@ -444,7 +444,7 @@ class DaemonsStartTest(AlignakTest):
             for daemon in daemons:
                 print(" - %s: %s", daemon['%s_name' % daemon_type], daemon['alive'])
                 assert daemon['alive']
-                assert not ('realm' in daemon)
+                assert not ('realms' in daemon)
                 assert 'realm_name' in daemon
 
         print("Testing get_running_id")

--- a/test/test_launch_daemons.py
+++ b/test/test_launch_daemons.py
@@ -532,7 +532,8 @@ class DaemonsStartTest(AlignakTest):
             for line in iter(proc.stderr.readline, b''):
                 print("*** " + line.rstrip())
             # The log contain some DEBUG log
-            assert debug_log
+            if sys.version_info >= (2, 7):
+                assert debug_log # Cannot set/get log level with python 2.6
             # The log do not contain any ERROR log
             assert not error_log
 

--- a/test/test_launch_daemons.py
+++ b/test/test_launch_daemons.py
@@ -22,6 +22,7 @@
 import os
 import time
 import signal
+import json
 
 import subprocess
 from time import sleep
@@ -266,7 +267,7 @@ class DaemonsStartTest(AlignakTest):
                     "-c", "./cfg/run_test_launch_daemons/daemons/%sd.ini" % daemon]
             self.procs[daemon] = \
                 subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            sleep(1)
+            sleep(0.1)
             print("- %s launched (pid=%d)" % (daemon, self.procs[daemon].pid))
 
         sleep(1)
@@ -335,8 +336,8 @@ class DaemonsStartTest(AlignakTest):
             data = raw_data.json()
             assert data == 'pong', "Daemon %s  did not ping back!" % name
 
-        print("Testing ping with satellite SSL and client not SSL")
         if ssl:
+            print("Testing ping with satellite SSL and client not SSL")
             for name, port in satellite_map.items():
                 raw_data = req.get("http://localhost:%s/ping" % port)
                 assert 'The client sent a plain HTTP request, but this server ' \
@@ -360,12 +361,14 @@ class DaemonsStartTest(AlignakTest):
         for daemon in ['scheduler', 'broker', 'poller', 'reactionner', 'receiver']:
             raw_data = req.get("%s://localhost:%s/have_conf" % (http, satellite_map[daemon]), verify=False)
             data = raw_data.json()
-            assert data, "Daemon %s has no conf!" % daemon
+            assert data == True, "Daemon %s has no conf!" % daemon
             # TODO: test with magic_hash
 
         print("Testing do_not_run")
-        for daemon in ['arbiter', 'scheduler', 'broker', 'poller', 'reactionner', 'receiver']:
+        for daemon in ['arbiter']:
             raw_data = req.get("%s://localhost:%s/do_not_run" % (http, satellite_map[daemon]), verify=False)
+            data = raw_data.json()
+            print("%s, do_not_run: %s" % (name, data))
 
         print("Testing api")
         name_to_interface = {'arbiter': ArbiterInterface,
@@ -378,7 +381,6 @@ class DaemonsStartTest(AlignakTest):
             raw_data = req.get("%s://localhost:%s/api" % (http, port), verify=False)
             data = raw_data.json()
             expected_data = set(name_to_interface[name](None).api())
-            assert isinstance(data, list), "Data is not a list!"
             assert set(data) == expected_data, "Daemon %s has a bad API!" % name
 
         print("Testing api_full")
@@ -391,6 +393,8 @@ class DaemonsStartTest(AlignakTest):
         for name, port in satellite_map.items():
             raw_data = req.get("%s://localhost:%s/api_full" % (http, port), verify=False)
             data = raw_data.json()
+            expected_data = set(name_to_interface[name](None).api_full())
+            assert set(data) == expected_data, "Daemon %s has a bad API!" % name
 
         # print("Testing get_checks on scheduler")
         # TODO: if have poller running, the poller will get the checks before us
@@ -408,6 +412,7 @@ class DaemonsStartTest(AlignakTest):
         for name, port in satellite_map.items():
             raw_data = req.get("%s://localhost:%s/get_raw_stats" % (http, port), verify=False)
             data = raw_data.json()
+            print("%s, raw stats: %s" % (name, data))
             if name == 'broker':
                 assert isinstance(data, list), "Data is not a list!"
             else:
@@ -417,9 +422,12 @@ class DaemonsStartTest(AlignakTest):
         for name, port in satellite_map.items():
             raw_data = req.get("%s://localhost:%s/what_i_managed" % (http, port), verify=False)
             data = raw_data.json()
+            print("%s, what I manage: %s" % (name, data))
             assert isinstance(data, dict), "Data is not a dict!"
             if name != 'arbiter':
                 assert 1 == len(data), "The dict must have 1 key/value!"
+            else:
+                assert 0 == len(data), "The dict must be empty!"
 
         print("Testing get_external_commands")
         for name, port in satellite_map.items():
@@ -430,9 +438,20 @@ class DaemonsStartTest(AlignakTest):
         print("Testing get_log_level")
         for name, port in satellite_map.items():
             raw_data = req.get("%s://localhost:%s/get_log_level" % (http, port), verify=False)
-            data = raw_data.json()
-            assert isinstance(data, unicode), "Data is not an unicode!"
-            # TODO: seems level get not same tham defined in *d.ini files
+            assert raw_data.json() == 'INFO'
+
+        print("Testing set_log_level")
+        for name, port in satellite_map.items():
+            raw_data = req.post("%s://localhost:%s/set_log_level" % (http, port),
+                                data=json.dumps({'loglevel': 'DEBUG'}),
+                                headers={'Content-Type': 'application/json'},
+                                verify=False)
+            assert raw_data.json() == 'DEBUG'
+
+        print("Testing get_log_level")
+        for name, port in satellite_map.items():
+            raw_data = req.get("%s://localhost:%s/get_log_level" % (http, port), verify=False)
+            assert raw_data.json() == 'DEBUG'
 
         print("Testing get_all_states")
         raw_data = req.get("%s://localhost:%s/get_all_states" % (http, satellite_map['arbiter']), verify=False)
@@ -443,8 +462,12 @@ class DaemonsStartTest(AlignakTest):
             print("Got Alignak state for: %ss / %d instances" % (daemon_type, len(daemons)))
             for daemon in daemons:
                 print(" - %s: %s", daemon['%s_name' % daemon_type], daemon['alive'])
+                print(" - %s: %s", daemon['%s_name' % daemon_type], daemon)
                 assert daemon['alive']
-                assert not ('realms' in daemon)
+                assert 'realms' not in daemon
+                assert 'confs' not in daemon
+                assert 'tags' not in daemon
+                assert 'con' not in daemon
                 assert 'realm_name' in daemon
 
         print("Testing get_running_id")
@@ -491,12 +514,22 @@ class DaemonsStartTest(AlignakTest):
         time.sleep(1)
 
         for name, proc in self.procs.items():
-            data = self._get_subproc_data(name)
+            self._get_subproc_data(name)
+            debug_log = False
+            error_log = False
             print("%s stdout:" % (name))
             for line in iter(proc.stdout.readline, b''):
+                if 'DEBUG:' in line:
+                    debug_log = True
+                if 'ERROR:' in line:
+                    error_log = True
                 print(">>> " + line.rstrip())
             print("%s stderr:" % (name))
             for line in iter(proc.stderr.readline, b''):
-                print(">>> " + line.rstrip())
+                print("*** " + line.rstrip())
+            # The log contain some DEBUG log
+            assert debug_log
+            # The log do not contain any ERROR log
+            assert not error_log
 
         print("Done testing")


### PR DESCRIPTION
Avoid uncatched JSON serialization error log (API get_all_states and scheduler objects dump)

Closes #534: Some properties existing in the Arbiter global configuration are not serializable and needs to get filtered. Some objects in the scheduler configuration can not be dumped correctly.

In both case a WARNING log is raised if any serialization happens. This will allow to detect if some other filters are to take place.

The `get_log_level` and `set_log_level` daemons API are also fixed with this PR.

-----

Some more to filter: http://pastebin.com/qiQD5LXm
