### PR TITLE
Exclude __str__ functions from code coverage

### DIFF
--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -3,6 +3,7 @@
 exclude_lines =
     pragma: no cover
     def __repr__
+    def __str__
     if self.debug:
     if settings.DEBUG
     raise AssertionError


### PR DESCRIPTION
The `__str__` functions are of no interest for code coverage measurements