### PR TITLE
Closes #643: passive checks are immediate HARD state

### DIFF
--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -639,6 +639,8 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         :return: True if self.attempt >= self.max_check_attempts, otherwise False
         :rtype: bool
         """
+        if self.passive_checks_enabled and not self.active_checks_enabled:
+            return True
         return self.attempt >= self.max_check_attempts
 
     def do_check_freshness(self, hosts, services, timeperiods, macromodulations, checkmodulations,

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -936,7 +936,7 @@ class TestDependencies(AlignakTest):
 
         assert 0 == len(svc.act_depend_of)
 
-        # it's passive, create check manually
+        # Set host and service as OK
         excmd = '[%d] PROCESS_HOST_CHECK_RESULT;test_host_E;0;Host is UP' % time.time()
         self.schedulers['scheduler-master'].sched.run_external_command(excmd)
         excmd = '[%d] PROCESS_SERVICE_CHECK_RESULT;test_host_E;test_ok_0;0;Service is OK' % time.time()
@@ -944,14 +944,35 @@ class TestDependencies(AlignakTest):
         self.external_command_loop()
         time.sleep(0.1)
         assert "UP" == host.state
+        assert "HARD" == host.state_type
         assert "OK" == svc.state
+        assert "HARD" == svc.state_type
+        self.assert_actions_count(0)
+
+        # Set host DOWN
+        excmd = '[%d] PROCESS_HOST_CHECK_RESULT;test_host_E;2;Host is DOWN' % time.time()
+        self.schedulers['scheduler-master'].sched.run_external_command(excmd)
+        self.external_command_loop()
+        time.sleep(0.1)
+        assert "DOWN" == host.state
+        assert "HARD" == host.state_type
+        self.assert_actions_count(1)
+
+        # Set host UP
+        excmd = '[%d] PROCESS_HOST_CHECK_RESULT;test_host_E;0;Host is UP' % time.time()
+        self.schedulers['scheduler-master'].sched.run_external_command(excmd)
+        self.external_command_loop()
+        time.sleep(0.1)
+        assert "UP" == host.state
+        assert "HARD" == host.state_type
+        self.assert_actions_count(2)
 
         excmd = '[%d] PROCESS_SERVICE_CHECK_RESULT;test_host_E;test_ok_0;2;Service is CRITICAL' % time.time()
         self.schedulers['scheduler-master'].sched.run_external_command(excmd)
         self.external_command_loop()
         assert "UP" == host.state
         assert "CRITICAL" == svc.state
-        self.assert_actions_count(0)
+        self.assert_actions_count(3)
         self.assert_checks_count(12)
 
     def test_ap_s_passive_service_check_active_host(self):


### PR DESCRIPTION
When testing max check attempts, if item is only passively checked, then raise an HARD state