### PR TITLE
Alignak monitoring configuration as an environment variable

### DIFF
--- a/bin/default/alignak.in
+++ b/bin/default/alignak.in
@@ -64,8 +64,12 @@ LIB=$LIB$
 ARBITERCFG="$ETC/daemons/arbiterd.ini"
 
 # location of the alignak configuration file
-# Please update $ETC$ instead of this one.
-ALIGNAKCFG="$ETC/alignak.cfg"
+# Now look if some required variables are pre defined:
+if ! test "$ALIGNAKCFG"
+then
+    # Please update $ETC$ instead of this one.
+    ALIGNAKCFG="$ETC/alignak.cfg"
+fi
 
 # We got 2 configs because tools like Centreon don't generate all
 # configuration (only the alignak.cfg part)

--- a/bin/init.d/alignak-arbiter
+++ b/bin/init.d/alignak-arbiter
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
 #

--- a/bin/init.d/alignak-broker
+++ b/bin/init.d/alignak-broker
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
 #

--- a/bin/init.d/alignak-poller
+++ b/bin/init.d/alignak-poller
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
 #

--- a/bin/init.d/alignak-reactionner
+++ b/bin/init.d/alignak-reactionner
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
 #

--- a/bin/init.d/alignak-receiver
+++ b/bin/init.d/alignak-receiver
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
 #

--- a/bin/init.d/alignak-scheduler
+++ b/bin/init.d/alignak-scheduler
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
 #


### PR DESCRIPTION
Allow to define Alignak monitoring configuration file  as an environment variable
Fix init.d scripts shebang

---

The ALIGNAKCFG shell variable used for the monitoring configuration file is ignored if it exists as an environment variable. This small modification allows to:
```
export ALIGNAKCFG='/tmp/alignak_cfg.cfg'
/usr/local/etc/init.d/alignak restart
```

Easier for testing some configurations :wink: 