### PR TITLE
Clean warning log for get_all_states - closes #634

### DIFF
--- a/alignak/http/arbiter_interface.py
+++ b/alignak/http/arbiter_interface.py
@@ -165,7 +165,7 @@ class ArbiterInterface(GenericInterface):
                     for prop in props:
                         if not hasattr(daemon, prop):
                             continue
-                        if prop in ["realms", "conf", "con", "tags"]:
+                        if prop in ["realms", "conf", "con", "tags", "modules", "conf_package"]:
                             continue
                         val = getattr(daemon, prop)
                         # give a try to a json able object


### PR DESCRIPTION
Add some more filter in the serializable data for the get_all_states arbiter API