### PR TITLE
Temporary workaround with a WARNING log for #675 

### DIFF
--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -740,8 +740,10 @@ class SchedulingItem(Item):  # pylint: disable=R0902
             # Check if the status is ok for impact
             if impact_id in hosts:
                 impact = hosts[impact_id]
-            else:
+            elif impact_id in services:
                 impact = services[impact_id]
+            else:
+                logger.warning("Problem with my impacts: %s", self)
             timeperiod = timeperiods[timeperiod_id]
             for stat in status:
                 if self.is_state(stat):


### PR DESCRIPTION
(missing impact service in the known services)

This PR does not fix the bug but protects against the exception and makes a WARNING log when it should occur. This to allow avoiding the scheduler stop !

The issue will not get closed and still need to be fixed !