### PR TITLE
Remove alignak_setup dependency

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -16,7 +16,7 @@ pep257
 # Tests time freeze
 freezegun
 # Alignak modules and checks packs installer
-alignak_setup
+#alignak_setup
 # Alignak example module (develop branch)
 -e git+git://github.com/Alignak-monitoring/alignak-module-example.git@develop#egg=alignak-module-example
 ordereddict==1.1


### PR DESCRIPTION
Thanks to the module installation refactoring there is no more need of the `alignak_setup` libray that was formerly used to install the Example module used by the tests suites.