### PR TITLE
Fix #685 : BP Rules: Consider downtime/acknowledged host/service as OK

### DIFF
--- a/test/test_business_correlator_notifications.py
+++ b/test/test_business_correlator_notifications.py
@@ -87,7 +87,7 @@ class TestBusinesscorrelNotifications(AlignakTest):
         self.scheduler_loop(1, [[svc_cor, None, None]])
         self.scheduler_loop(1, [[svc_cor, None, None]])
 
-        assert 2 == svc_cor.business_rule.get_state(self._sched.hosts,
+        assert 0 == svc_cor.business_rule.get_state(self._sched.hosts,
                                                             self._sched.services)
         timeperiod = self._sched.timeperiods[svc_cor.notification_period]
         host = self._sched.hosts[svc_cor.host]


### PR DESCRIPTION
* Improve the function giving a Node state for a BP rule to consider an host/service in downtime/acknowledgement as UP/OK state
* Add new cases in the tests for this previous change
* Improve the understanding of business correlator's tests by modifying the comments 