### PR TITLE
 Fix #698: don't have multiple notification way when using a contact template

### DIFF
--- a/alignak/objects/contact.py
+++ b/alignak/objects/contact.py
@@ -505,4 +505,5 @@ class Contacts(CommandCallItems):
                 if not hasattr(contact, 'notificationways'):
                     contact.notificationways = [nw_name]
                 else:
+                    contact.notificationways = list(contact.notificationways)
                     contact.notificationways.append(nw_name)

--- a/test/cfg/cfg_notification_ways.cfg
+++ b/test/cfg/cfg_notification_ways.cfg
@@ -9,6 +9,31 @@ define command{
     command_line    $USER1$/notifier.pl --hostname $HOSTNAME$ --servicedesc $SERVICEDESC$ --notificationtype $NOTIFICATIONTYPE$ --servicestate $SERVICESTATE$ --serviceoutput $SERVICEOUTPUT$ --longdatetime $LONGDATETIME$ --serviceattempt $SERVICEATTEMPT$ --servicestatetype $SERVICESTATETYPE$
 }
 
+define command{
+    command_name    notify-host-work
+    command_line    $USER1$/notifier.pl --hostname $HOSTNAME$ --notificationtype $NOTIFICATIONTYPE$ --hoststate $HOSTSTATE$ --hostoutput $HOSTOUTPUT$ --longdatetime $LONGDATETIME$ --hostattempt $HOSTATTEMPT$ --hoststatetype $HOSTSTATETYPE$
+}
+
+define command{
+    command_name    notify-service-work
+    command_line    $USER1$/notifier.pl --hostname $HOSTNAME$ --servicedesc $SERVICEDESC$ --notificationtype $NOTIFICATIONTYPE$ --servicestate $SERVICESTATE$ --serviceoutput $SERVICEOUTPUT$ --longdatetime $LONGDATETIME$ --serviceattempt $SERVICEATTEMPT$ --servicestatetype $SERVICESTATETYPE$
+}
+
+define contactgroup{
+    contactgroup_name       test_contact_template
+    alias                   test_contacts_template_alias
+    members                 test_contact_template_1, test_contact_template_2
+}
+
+define contact{
+    name                            contact_template
+    host_notifications_enabled      1
+    service_notifications_enabled   1
+    email                           nobody@localhost
+    notificationways                email_in_work
+    can_submit_commands             1
+    register                        0
+}
 
 define contact{
     contact_name                    test_contact
@@ -34,6 +59,33 @@ define contact{
     can_submit_commands             1
 }
 
+define contact{
+    use                             contact_template
+    contact_name                    test_contact_template_1
+    alias                           test_contact_alias_3
+    service_notification_period     24x7
+    host_notification_period        24x7
+    service_notification_options    w,u,c,r,f
+    host_notification_options       d,u,r,f,s
+    service_notification_commands   notify-service
+    host_notification_commands      notify-host
+    email                           nobody@localhost
+    can_submit_commands             1
+}
+
+define contact{
+    use                             contact_template
+    contact_name                    test_contact_template_2
+    alias                           test_contact_alias_4
+    service_notification_period     24x7
+    host_notification_period        24x7
+    service_notification_options    w,u,c,r,f
+    host_notification_options       d,u,r,f,s
+    service_notification_commands   notify-service-sms
+    host_notification_commands      notify-host-sms
+    email                           nobody@localhost
+    can_submit_commands             1
+}
 
 
 #EMail the whole 24x7 is ok
@@ -58,6 +110,54 @@ define notificationway{
        host_notification_commands      notify-host-sms
        min_criticity		       5
 
+define notificationway{
+       notificationway_name	email_in_work
+       service_notification_period     work
+       host_notification_period        work
+       service_notification_options    w,u,c,r,f
+       host_notification_options       d,u,r,f,s
+       service_notification_commands   notify-service-work
+       host_notification_commands      notify-host-work
+}
+
+define host{
+  check_interval                 1
+  check_period                   24x7
+  contact_groups                 test_contact_template
+  event_handler_enabled          1
+  failure_prediction_enabled     1
+  flap_detection_enabled         1
+  max_check_attempts             3
+  host_name                      test_host_contact_template
+  notification_interval          1
+  notification_options           d,u,r,f,s
+  notification_period            24x7
+  notifications_enabled          1
+  process_perf_data              1
+  retain_nonstatus_information   1
+  retain_status_information      1
+  retry_interval                 1
+  notes_url                      /alignak/wiki/doku.php/$HOSTNAME$
+  action_url                     /alignak/pnp/index.php?host=$HOSTNAME$
+  check_command                  check-host-alive-parent!up!$HOSTSTATE:test_router_0$
+}
+
+define service{
+  action_url                     http://search.cpan.org/dist/Monitoring-Generator-TestConfig/
+  active_checks_enabled          1
+  check_command                  check_service!ok
+  check_interval                 1
+  host_name                      test_host_contact_template
+  icon_image                     ../../docs/images/tip.gif
+  icon_image_alt                 icon alt string
+  notes                          just a notes string
+  notes_url                      http://search.cpan.org/dist/Monitoring-Generator-TestConfig/README
+  retry_interval                 1
+  service_description            test_ok_contact_template
+  servicegroups                  servicegroup_01,ok
+  use                            generic-service
+  event_handler                  eventhandler
+}
 
 define timeperiod{
     timeperiod_name night
@@ -69,4 +169,16 @@ define timeperiod{
     thursday        00:00-07:30
     friday          00:00-07:30
     saturday        00:00-07:30
+}
+
+define timeperiod{
+    timeperiod_name work
+    alias           work
+    sunday          07:00-17:30
+    monday          07:00-17:30
+    tuesday         07:00-17:30
+    wednesday       07:00-17:30
+    thursday        07:00-17:30
+    friday          07:00-17:30
+    saturday        07:00-17:30
 }

--- a/test/test_notifway.py
+++ b/test/test_notifway.py
@@ -244,6 +244,27 @@ class TestNotificationWay(AlignakTest):
         assert False == email_in_day.want_service_notification(self._sched.timeperiods,
                                                                now, 'WARNING', 'PROBLEM', -1)
 
+        # Test the heritage for notification ways
+        host_template = self._sched.hosts.find_by_name("test_host_contact_template")
+        contact_template_1 = self._sched.contacts[host_template.contacts[0]]
+        commands_contact_template_1 = contact_template_1.get_notification_commands(self._sched.notificationways,'host')
+        contact_template_2 = self._sched.contacts[host_template.contacts[1]]
+        commands_contact_template_2 = contact_template_2.get_notification_commands(self._sched.notificationways,'host')
+
+        resp = sorted([sorted([command.get_name() for command in commands_contact_template_1]),
+                       sorted([command.get_name() for command in commands_contact_template_2])])
+
+        assert sorted([['notify-host', 'notify-host-work'], ['notify-host-sms', 'notify-host-work']]) == resp
+
+        contact_template_1 = self._sched.contacts[host_template.contacts[0]]
+        commands_contact_template_1 = contact_template_1.get_notification_commands(self._sched.notificationways,'service')
+        contact_template_2 = self._sched.contacts[host_template.contacts[1]]
+        commands_contact_template_2 = contact_template_2.get_notification_commands(self._sched.notificationways,'service')
+        resp = sorted([sorted([command.get_name() for command in commands_contact_template_1]),
+                       sorted([command.get_name() for command in commands_contact_template_2])])
+
+        assert sorted([['notify-service', 'notify-service-work'], ['notify-service-sms', 'notify-service-work']]) == resp
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Using pdb, we can see that contact.notificationways is the same object (Same memory address) for each contacts using the same template. Using list() create a new object for each contact and correct the problem
* Add new case for testing this change