### PR TITLE
Add a log for performance data when TEST_LOG_ACTIONS is set

### DIFF
--- a/alignak/action.py
+++ b/alignak/action.py
@@ -272,6 +272,8 @@ class ActionBase(AlignakObject):
         if self.log_actions:
             logger.info("Check result for '%s': %d, %s",
                         self.command, self.exit_status, self.output)
+            logger.info("Performance data for '%s': %s",
+                        self.command, self.perf_data)
 
     def check_finished(self, max_plugins_output_length):
         """Handle action if it is finished (get stdout, stderr, exit code...)


### PR DESCRIPTION
When activating the extra logs with the environment variable `TEST_LOG_ACTIONS` the plugins performance data are not logged. Having them in the log may help setting-up a monitoring configuration