### PR TITLE
Closes #737 - add an update retention status brok for the ...

### DIFF
--- a/alignak/brok.py
+++ b/alignak/brok.py
@@ -60,7 +60,7 @@ class Brok(object):
     Broker can do whatever he wants with it.
 
     Broks types:
-    - log
+    - log (deprecated)
     - monitoring_log
 
     - notification_raise
@@ -68,9 +68,12 @@ class Brok(object):
     - downtime_raise
     - acknowledge_expire
     - downtime_expire
+    
     - initial_host_status, initial_service_status, initial_contact_status
     - initial_broks_done
 
+    - host_retention_status, service_retention_status, contact_retention_status
+    
     - update_host_status, update_service_status, initial_contact_status
     - host_check_result, service_check_result
     - host_next_schedule, service_next_scheduler

--- a/alignak/brok.py
+++ b/alignak/brok.py
@@ -68,12 +68,12 @@ class Brok(object):
     - downtime_raise
     - acknowledge_expire
     - downtime_expire
-    
+
     - initial_host_status, initial_service_status, initial_contact_status
     - initial_broks_done
 
     - host_retention_status, service_retention_status, contact_retention_status
-    
+
     - update_host_status, update_service_status, initial_contact_status
     - host_check_result, service_check_result
     - host_next_schedule, service_next_scheduler

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -647,6 +647,17 @@ class Item(AlignakObject):
         self.fill_data_brok_from(data, 'check_result')
         return Brok({'type': self.my_type + '_check_result', 'data': data})
 
+    def get_retention_status_brok(self):
+        """
+        Create retention_status brok
+
+        :return: Brok object
+        :rtype: object
+        """
+        data = {}
+        self.fill_data_brok_from(data, 'check_result')
+        return Brok({'type': self.my_type + '_retention_status', 'data': data})
+
     def get_next_schedule_brok(self):
         """
         Create next_schedule (next check) brok

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -1549,6 +1549,7 @@ class Scheduler(object):  # pylint: disable=R0902
             if comm is not None:
                 new_notified_contacts.add(comm.uuid)
         item.notified_contacts = new_notified_contacts
+        self.add_brok(item.get_retention_status_brok())
 
     def fill_initial_broks(self, bname, with_logs=False):
         """Create initial broks for a specific broker

--- a/test/test_retention.py
+++ b/test/test_retention.py
@@ -172,3 +172,16 @@ class Testretention(AlignakTest):
         # acknowledge
         assert True == svcn.problem_has_been_acknowledged
 
+        self._sched = self.schedulers['scheduler-master'].sched
+        host_broks = []
+        service_broks = []
+        for brok in sorted(self._sched.brokers['broker-master']['broks'].itervalues(),
+                           key=lambda x: x.creation_time):
+            if brok.type == 'host_retention_status':
+                print("Host retention: %s" % brok)
+                host_broks.append(brok)
+            if brok.type == 'service_retention_status':
+                print("Service retention: %s" % brok)
+                service_broks.append(brok)
+        assert len(host_broks) == 2
+        assert len(service_broks) == 1


### PR DESCRIPTION
...retention restored items

This PR adds host_update_retention and service_update_retention broks that are created by the scheduler when the retention stored data are restored. It belongs to the broker modules to manage or not those specific broks if needed.