### PR TITLE
No contacts services raise notifications to host contacts

### DIFF
--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -331,6 +331,12 @@ class Host(SchedulingItem):  # pylint: disable=R0904
                     self.configuration_errors.append(msg)
                     state = False
 
+        # Ok now we manage special cases...
+        if self.notifications_enabled and self.contacts == []:
+            msg = "[%s::%s] notifications are enabled but no contacts nor contact_groups " \
+                  "property is defined for this host" % (self.my_type, self.get_name())
+            self.configuration_warnings.append(msg)
+
         return super(Host, self).is_correct() and state
 
     def get_services(self):

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -3035,13 +3035,6 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         if not hasattr(self, 'notification_period'):
             self.notification_period = None
 
-        # Ok now we manage special cases...
-        if self.notifications_enabled and self.contacts == []:
-            msg = "[%s::%s] no contacts nor contact_groups property" % (
-                self.my_type, self.get_name()
-            )
-            self.configuration_warnings.append(msg)
-
         # If we got an event handler, it should be valid
         if getattr(self, 'event_handler', None) and not self.event_handler.is_valid():
             msg = "[%s::%s] event_handler '%s' is invalid" % (

--- a/test/alignak_test.py
+++ b/test/alignak_test.py
@@ -452,9 +452,9 @@ class AlignakTest(unittest.TestCase):
                 else:
                     hst = self.schedulers['scheduler-master'].sched.find_item_by_id(item.host)
                     ref = "host: %s svc: %s" % (hst.get_name(), item.get_name())
-                print "NOTIFICATION %s %s %s %s %s" % (a.uuid, ref, a.type,
+                print "NOTIFICATION %s %s %s %s %s %s" % (a.uuid, ref, a.type,
                                                        time.asctime(time.localtime(a.t_to_go)),
-                                                       a.status)
+                                                       a.status, a.contact_name)
             elif a.is_a == 'eventhandler':
                 print "EVENTHANDLER:", a
         print "--- actions >>>----------------------------------"

--- a/test/cfg/nonotif/services.cfg
+++ b/test/cfg/nonotif/services.cfg
@@ -3,7 +3,6 @@ define service{
   check_freshness                0
   check_interval                 1
   check_period                   24x7
-  contact_groups                 test_contact
   event_handler_enabled          0
   failure_prediction_enabled     1
   flap_detection_enabled         1
@@ -25,6 +24,8 @@ define service{
 }
 
 define service{
+  contact_groups                 test_contact
+
   active_checks_enabled          1
   check_command                  check_service!ok
   check_interval                 1
@@ -34,6 +35,28 @@ define service{
   notes                          just a notes string
   retry_interval                 1
   service_description            test_ok_0
+  servicegroups                  servicegroup_01,ok
+  use                            generic-service
+  event_handler                  eventhandler
+  notes_url                      /alignak/wiki/doku.php/$HOSTNAME$/$SERVICEDESC$
+  action_url                     /alignak/pnp/index.php?host=$HOSTNAME$&srv=$SERVICEDESC$
+  _custname			 custvalue
+}
+
+define service{
+  ; No defined contact nor contacts group
+  ; but notifications are enabled
+  notifications_enabled          1
+
+  active_checks_enabled          1
+  check_command                  check_service!ok
+  check_interval                 1
+  host_name                      test_host_0
+  icon_image                     ../../docs/images/tip.gif?host=$HOSTNAME$&srv=$SERVICEDESC$
+  icon_image_alt                 icon alt string
+  notes                          just a notes string
+  retry_interval                 1
+  service_description            test_ok_no_contacts
   servicegroups                  servicegroup_01,ok
   use                            generic-service
   event_handler                  eventhandler


### PR DESCRIPTION
Closes #753:
 - Raise a configuration warning log only for hosts that do not have any contact if they have enabled notification
 - Add a test to confirm that notifications are sent to host contacts when a service has no defined contacts