### PR TITLE
Host downtime acknowledges the host

### DIFF
--- a/alignak/external_command.py
+++ b/alignak/external_command.py
@@ -1029,8 +1029,8 @@ class ExternalCommandManager:
 
         :param service: service to acknowledge the problem
         :type service: alignak.objects.service.Service
-        :param sticky: acknowledge will be always present is host return in UP state
-        :type sticky: integer
+        :param sticky: if sticky == 2, the acknowledge will remain until the service returns to an
+        OK state else the acknowledge will be removed as soon as the service state changes
         :param notify: if to 1, send a notification
         :type notify: integer
         :param author: name of the author or the acknowledge
@@ -1052,7 +1052,8 @@ class ExternalCommandManager:
 
         :param host: host to acknowledge the problem
         :type host: alignak.objects.host.Host
-        :param sticky: acknowledge will be always present is host return in UP state
+        :param sticky: if sticky == 2, the acknowledge will remain until the host returns to an
+        UP state else the acknowledge will be removed as soon as the host state changes
         :type sticky: integer
         :param notify: if to 1, send a notification
         :type notify: integer
@@ -1066,14 +1067,6 @@ class ExternalCommandManager:
         notif_period = self.daemon.timeperiods[host.notification_period]
         host.acknowledge_problem(notif_period, self.hosts, self.services, sticky, notify, author,
                                  comment)
-        brok = make_monitoring_log('info',
-                                   'HOST ACKNOWLEDGE: '
-                                   'this command is not implemented!')
-        self.send_an_element(brok)
-        for service_id in self.daemon.hosts[host.uuid].services:
-            if service_id in self.daemon.services:
-                self.acknowledge_svc_problem(self.daemon.services[service_id],
-                                             sticky, notify, author, comment)
 
     def acknowledge_svc_problem_expire(self, service, sticky, notify, end_time, author, comment):
         """Acknowledge a service problem with expire time for this acknowledgement
@@ -3460,6 +3453,7 @@ class ExternalCommandManager:
         downtime = Downtime(data)
         downtime.add_automatic_comment(host)
         host.add_downtime(downtime)
+
         self.daemon.get_and_register_status_brok(host)
         if trigger_id != '' and trigger_id != 0:
             for item in self.daemon.hosts:
@@ -3485,7 +3479,7 @@ class ExternalCommandManager:
 
     def schedule_host_svc_downtime(self, host, start_time, end_time, fixed,
                                    trigger_id, duration, author, comment):
-        """Schedule a service downtime for each service of a host
+        """Schedule a service downtime for each service of an host
         Format of the line that triggers function call::
 
         SCHEDULE_HOST_SVC_DOWNTIME;<host_name>;<start_time>;<end_time>;

--- a/alignak/notification.py
+++ b/alignak/notification.py
@@ -133,8 +133,8 @@ class Notification(Action):  # pylint: disable=R0902
             return True
 
     def __str__(self):
-        return "Notification %s status:%s command:%s ref:%s t_to_go:%s" % \
-               (self.uuid, self.status, self.command, getattr(self, 'ref', 'unknown'),
+        return "Notification %s type:%s status:%s command:%s ref:%s t_to_go:%s" % \
+               (self.uuid, self.type, self.status, self.command, getattr(self, 'ref', 'unknown'),
                 time.asctime(time.localtime(self.t_to_go)))
 
     def get_return_from(self, notif):

--- a/alignak/objects/item.py
+++ b/alignak/objects/item.py
@@ -529,7 +529,8 @@ class Item(AlignakObject):
         :type comment_id: int
         :return: None
         """
-        del self.comments[comment_id]
+        if comment_id in self.comments:
+            del self.comments[comment_id]
 
     def prepare_for_conf_sending(self):
         """

--- a/test/test_brok_ack_downtime.py
+++ b/test/test_brok_ack_downtime.py
@@ -159,13 +159,31 @@ class TestBrokAckDowntime(AlignakTest):
         for brok in self.schedulers['scheduler-master'].sched.brokers['broker-master'][
             'broks'].itervalues():
             if brok.type == 'acknowledge_raise':
+                print("Brok: %s" % brok)
                 brok_ack.append(brok)
 
-        assert len(brok_ack) == 1
+        # Got one brok for the host ack and one brok for the service ack
+        assert len(brok_ack) == 2
 
+        host_brok = False
+        service_brok = False
         hdata = unserialize(brok_ack[0].data)
         assert hdata['host'] == 'test_host_0'
-        assert 'service' not in hdata
+        if 'service' in hdata:
+            assert hdata['service'] == 'test_ok_0'
+            service_brok = True
+        else:
+            host_brok = True
+
+        hdata = unserialize(brok_ack[1].data)
+        assert hdata['host'] == 'test_host_0'
+        if 'service' in hdata:
+            assert hdata['service'] == 'test_ok_0'
+            service_brok = True
+        else:
+            host_brok = True
+
+        assert host_brok and service_brok
 
         # return host in UP mode, so the acknowledge will be removed by the scheduler
         self.schedulers['scheduler-master'].sched.brokers['broker-master']['broks'] = {}
@@ -179,11 +197,27 @@ class TestBrokAckDowntime(AlignakTest):
                 brok_ack_expire.append(brok)
 
         assert len(brok_ack_raise) == 0
-        assert len(brok_ack_expire) == 1
+        assert len(brok_ack_expire) == 2
 
+        host_brok = False
+        service_brok = False
         hdata = unserialize(brok_ack_expire[0].data)
         assert hdata['host'] == 'test_host_0'
-        assert 'service' not in hdata
+        if 'service' in hdata:
+            assert hdata['service'] == 'test_ok_0'
+            service_brok = True
+        else:
+            host_brok = True
+
+        hdata = unserialize(brok_ack_expire[1].data)
+        assert hdata['host'] == 'test_host_0'
+        if 'service' in hdata:
+            assert hdata['service'] == 'test_ok_0'
+            service_brok = True
+        else:
+            host_brok = True
+
+        assert host_brok and service_brok
 
         # Do same but end with external commands:
         self.scheduler_loop(1, [[host, 2, 'DOWN'], [svc, 2, 'CRITICAL']])


### PR DESCRIPTION
Closes #752 - scheduling a downtime for an host acknowledges the host

The acknowledge for the host is set only when the downtime starts. Note that acknowledging an host will also acknowledge all its services that are currently problems.