### PR TITLE
Improve tests (service / hostgroups)

### DIFF
--- a/test/cfg/hostgroup/hostgroups_from_service.cfg
+++ b/test/cfg/hostgroup/hostgroups_from_service.cfg
@@ -1,0 +1,81 @@
+cfg_dir=../default
+
+# Issue #65
+
+# Host template
+define host{
+    name                             template01
+    check_interval                   4
+    max_check_attempts               6
+    register                         0
+
+    check_period                     24x7
+}
+
+# Hosts
+define host{
+    use                             template01
+    host_name                       srv01
+    address                         192.168.1.11
+    check_command                   check_tcp!3306!5!8
+    event_handler                   my_host_event_handler
+    hostgroups                      tcp_hosts
+}
+
+define host{
+    use                             template01
+    host_name                       srv02
+    address                         192.168.1.12
+    check_command                   check_tcp!80!5!8
+    event_handler                   my_host_event_handler
+    hostgroups                      tcp_hosts
+}
+
+define host{
+    use                             template01
+    host_name                       srv03
+    address                         192.168.1.13
+    check_command                   check_tcp
+    event_handler                   my_host_event_handler
+    hostgroups                      tcp_hosts
+}
+
+
+define command{
+    command_name                    check_tcp
+    command_line                    $PLUGINSDIR$/check_tcp  -H $HOSTADDRESS$ -p $ARG1$
+}
+
+define command{
+    command_name     my_host_event_handler
+    command_line     /home/alignak/eventhandler.sh "ALIGNAK-EVENT HOST hHOSTNAME $HOSTNAME$"
+}
+
+define timeperiod{
+    timeperiod_name		24x7
+    alias				Always
+    sunday				00:00-24:00
+    monday				00:00-24:00
+    tuesday				00:00-24:00
+    wednesday			00:00-24:00
+    thursday			00:00-24:00
+    friday				00:00-24:00
+    saturday			00:00-24:00
+}
+define timeperiod{
+    timeperiod_name		none
+    alias				Never
+}
+
+
+define service {
+    use						generic-service
+    hostgroup_name			tcp_hosts
+    service_description 	TCP
+    check_command			check_tcp
+}
+
+define hostgroup {
+    hostgroup_name 		    tcp_hosts
+    alias				    TCP Servers
+}

--- a/test/test_hostgroup.py
+++ b/test/test_hostgroup.py
@@ -265,3 +265,33 @@ class TestHostGroup(AlignakTest):
                 "test_With another Spaces"
             ) is not \
             []
+
+    def test_service_hostgroup(self):
+        """Test hosts services inherited from a hostgroups property in service definition
+
+        :return: None
+        """
+        self.print_header()
+        self.setup_with_file('cfg/hostgroup/hostgroups_from_service.cfg')
+        assert self.schedulers['scheduler-master'].conf.conf_is_correct
+
+        #  Search a hostgroup named tcp_hosts
+        hg = self.schedulers['scheduler-master'].sched.hostgroups.find_by_name("tcp_hosts")
+        assert isinstance(hg, Hostgroup)
+        print(hg.__dict__)
+
+        assert len(self.schedulers['scheduler-master'].sched.hostgroups.get_members_by_name("tcp_hosts")) == 3
+
+        assert len(hg.members) == 3
+        assert len(hg.hostgroup_members) == 0
+
+        assert len(hg.get_hosts()) == 3
+        print("Hostgroup hosts:")
+        for host_id in hg.members:
+            host = self.schedulers['scheduler-master'].sched.hosts[host_id]
+            print("- host: %s" % host.get_name())
+            assert len(host.services) > 0
+            for service_uuid in host.services:
+                service = self.schedulers['scheduler-master'].sched.services[service_uuid]
+                print("  has a service: %s" % service.get_name())
+                assert 'TCP' == service.get_name()


### PR DESCRIPTION
Add a test to confirm that services can be inherited from an hostgroups property in the service definition