### PR TITLE
Reuse pid file if the pid is the same as ours

### DIFF
--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -537,6 +537,9 @@ class Daemon(object):
             logger.warning("pidfile is empty or has an invalid content: %s", self.pidfile)
             return
 
+        if pid == os.getpid():
+            return
+
         try:
             logger.info("Killing process: '%s'", pid)
             os.kill(pid, 0)


### PR DESCRIPTION
Fix issue #777.
If the pid in the pid file is the same as ours, reuse the pid file and continue normally.