### PR TITLE
Alignak configuration hook

### DIFF
--- a/alignak/brok.py
+++ b/alignak/brok.py
@@ -77,7 +77,8 @@ class Brok(object):
     - host_snapshot, service_snapshot
     - unknown_host_check_result, unknown_service_check_result
 
-    - program_status
+    - program_status, initial program status
+    - update_program_status, program status updated (raised on each scheduler loop)
     - clean_all_my_instance_id
 
     - new_conf

--- a/alignak/daemons/arbiterdaemon.py
+++ b/alignak/daemons/arbiterdaemon.py
@@ -110,6 +110,7 @@ class Arbiter(Daemon):  # pylint: disable=R0902
         self.verify_only = verify_only
         self.analyse = analyse
         self.arbiter_name = arbiter_name
+        self.alignak_name = None
 
         self.broks = {}
         self.is_master = False
@@ -245,6 +246,8 @@ class Arbiter(Daemon):  # pylint: disable=R0902
             sys.exit(err)
 
         logger.info("I correctly loaded the configuration files")
+        self.alignak_name = getattr(self.conf, "alignak_name", self.arbiter_name)
+        logger.info("Configuration for Alignak: %s", self.alignak_name)
 
         # First we need to get arbiters and modules
         # so we can ask them for objects
@@ -545,6 +548,9 @@ class Arbiter(Daemon):  # pylint: disable=R0902
                 key = '$' + key[1:].upper()
             # properties valued as None are filtered
             if value is None:
+                continue
+            # properties valued as empty strings are filtered
+            if value == '':
                 continue
             # set properties as legacy Shinken configuration files
             params.append("%s=%s" % (key, value))

--- a/alignak/daemons/schedulerdaemon.py
+++ b/alignak/daemons/schedulerdaemon.py
@@ -220,7 +220,7 @@ class Alignak(BaseSatellite):
             return
         logger.info("New configuration received")
         self.setup_new_conf()
-        logger.info("New configuration loaded")
+        logger.info("New configuration loaded, scheduling Alignak: %s", self.sched.alignak_name)
         self.sched.run()
 
     def setup_new_conf(self):
@@ -268,6 +268,7 @@ class Alignak(BaseSatellite):
             # Tag the conf with our data
             self.conf = conf
             self.conf.push_flavor = new_c['push_flavor']
+            self.conf.alignak_name = new_c['alignak_name']
             self.conf.instance_name = instance_name
             self.conf.skip_initial_broks = new_c['skip_initial_broks']
             self.conf.accept_passive_unknown_check_results = \

--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -449,6 +449,7 @@ class Dispatcher:
                         'conf': realm.serialized_confs[conf.uuid],
                         'override_conf': sched.get_override_configuration(),
                         'modules': sched.modules,
+                        'alignak_name': self.arbiter.arbiter_name,
                         'satellites': satellites,
                         'instance_name': sched.scheduler_name,
                         'push_flavor': conf.push_flavor,

--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -156,8 +156,13 @@ class Config(Item):  # pylint: disable=R0904,R0902
     properties = {
         # Used for the PREFIX macro
         # Alignak prefix does not axist as for Nagios meaning.
-        # It is better to set this value as an empty string rather than an meaningless information!
+        # It is better to set this value as an empty string rather than a meaningless information!
         'prefix':
+            StringProp(default=''),
+
+        # Used for the PREFIX macro
+        # Alignak instance name is set as tha arbiter name if it is not defined in the config
+        'alignak_name':
             StringProp(default=''),
 
         # Used for the MAINCONFIGFILE macro
@@ -648,6 +653,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
 
     macros = {
         'PREFIX':               'prefix',
+        'ALIGNAK':              'alignak_name',
         'MAINCONFIGFILE':       'main_config_file',
         'STATUSDATAFILE':       '',
         'COMMENTDATAFILE':      '',
@@ -858,8 +864,8 @@ class Config(Item):  # pylint: disable=R0904,R0902
         """
         clean_params = self.clean_params(params)
 
+        logger.info("Alignak parameters:")
         for key, value in clean_params.items():
-
             if key in self.properties:
                 val = self.properties[key].pythonize(clean_params[key])
             elif key in self.running_properties:
@@ -877,6 +883,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
                 val = ToGuessProp.pythonize(clean_params[key])
 
             setattr(self, key, val)
+            logger.info("- : %s = %s", key, val)
             # Maybe it's a variable as $USER$ or $ANOTHERVATRIABLE$
             # so look at the first character. If it's a $, it's a variable
             # and if it's end like it too
@@ -2029,10 +2036,8 @@ class Config(Item):  # pylint: disable=R0904,R0902
         :return: True if the configuration is correct else False
         :rtype: bool
         """
-        logger.info(
-            'Running pre-flight check on configuration data, initial state: %s',
-            self.conf_is_correct
-        )
+        logger.info('Running pre-flight check on configuration data, initial state: %s',
+                    self.conf_is_correct)
         valid = self.conf_is_correct
 
         # Globally unmanaged parameters

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -187,6 +187,9 @@ class Scheduler(object):  # pylint: disable=R0902
         # And a dummy push flavor
         self.push_flavor = 0
 
+        # Alignak instance name
+        self.alignak_name = None
+
         # Now fake initialize for our satellites
         self.brokers = {}
         self.pollers = {}
@@ -272,6 +275,8 @@ class Scheduler(object):  # pylint: disable=R0902
         self.instance_name = conf.instance_name
         # and push flavor
         self.push_flavor = conf.push_flavor
+        # and Alignak instance name
+        self.alignak_name = conf.alignak_name
 
         # Update our hosts/services freshness threshold
         if self.conf.check_host_freshness and self.conf.host_freshness_check_interval >= 0:
@@ -1522,8 +1527,13 @@ class Scheduler(object):  # pylint: disable=R0902
         TODO: GET REAL VALUES
         """
         now = int(time.time())
+        # todo: some information in this brok are unuseful: last_log_rotation, command_file
+        # Some others are unaccurate: last_command_check, modified_host_attributes,
+        # modified_service_attributes
+        # I do not remove yet because some modules may use them?
         data = {"is_running": 1,
                 "instance_id": self.instance_id,
+                "alignak_name": self.alignak_name,
                 "instance_name": self.instance_name,
                 "last_alive": now,
                 "interval_length": self.conf.interval_length,

--- a/etc/alignak.cfg
+++ b/etc/alignak.cfg
@@ -59,6 +59,13 @@ cfg_dir=arbiter/packs/resource.d
 # Alignak framework configuration part
 # -------------------------------------------------------------------------
 
+# Alignak instance name
+# This information is useful to get/store alignak global configuration in the Alignak backend
+# If you share the same backend between several Alignak instances, each instance must have its own
+# name. The default is to use the arbiter name as Alignak instance name. Else, you can can define
+# your own Alignak instance name in this property
+# alignak_name=my_alignak
+
 # Notifications configuration
 # ---
 # Notifications are enabled/disabled

--- a/test/test_properties_default.py
+++ b/test/test_properties_default.py
@@ -129,6 +129,7 @@ class TestConfig(PropertiesTester, AlignakTest):
 
     properties = dict([
         ('prefix', ''),
+        ('alignak_name', ''),
         ('config_base_dir', ''),
         ('triggers_dir', ''),
         ('packs_dir', ''),


### PR DESCRIPTION
Use the `get_alignak_configuration` hook function of Arbiter modules if it exists to update the global Alignak configuration parameters and macros