### PR TITLE
Use ubuntu 2014 instead ubuntu 2012 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-sudo: true
+dist: trusty
+sudo: required
 python:
   - "2.6"
   - "2.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ importlib
 termcolor==1.1.0
 setproctitle
 ujson
-numpy
+numpy<1.12.0; python_version < '2.7'
+numpy; python_version >= '2.7'
 pyopenssl>=0.15
 docopt

--- a/test/setup_test.sh
+++ b/test/setup_test.sh
@@ -29,7 +29,7 @@ pip install --upgrade pip
 # install prog AND tests requirements :
 pip install -e .
 pip install alignak-setup
-pip install -r test/requirements.txt
+pip install --upgrade -r test/requirements.txt
 
 pyversion=$(python -c "import sys; print(''.join(map(str, sys.version_info[:2])))")
 if test -e "test/requirements.py${pyversion}.txt"


### PR DESCRIPTION
Update setup test script to instal + UPDATE python packages in the requirements
Update requirements for numpy < 1.12.0 for python 2.6