### PR TITLE
Use requests lib <=2.14.2 else some tests using requests-mock are bro…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@
 # They are not added as hard dependencie here so that packaging works fine
 # CherryPy is not packaged anymore since v3.5XX so we let it as is.
 CherryPy<9.0.0
-requests>=2.7.0
+
+# Version <=2.14.2 else some tests using requests-mock are broken with the 2.16.0 version
+requests>=2.7.0,<=2.14.2
+
 importlib
 termcolor==1.1.0
 setproctitle


### PR DESCRIPTION
…ken with the 2.16.0 version