### PR TITLE
[WiP] For #845, add some tests for the macros

### DIFF
--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -216,6 +216,8 @@ class Host(SchedulingItem):  # pylint: disable=R0904
         'HOSTPERCENTCHANGE': 'percent_state_change',
         'HOSTGROUPNAME':     ('get_groupname', ['hostgroups']),
         'HOSTGROUPNAMES':    ('get_groupnames', ['hostgroups']),
+        'HOSTGROUPALIAS':    ('get_groupalias', ['hostgroups']),
+        'HOSTGROUPALIASES':  ('get_groupaliases', ['hostgroups']),
         'LASTHOSTCHECK':     'last_chk',
         'LASTHOSTSTATECHANGE': 'last_state_change',
         'LASTHOSTUP':        'last_time_up',
@@ -367,32 +369,48 @@ class Host(SchedulingItem):  # pylint: disable=R0904
                 return 'UNNAMEDHOSTTEMPLATE'
 
     def get_groupname(self, hostgroups):
-        """Get alias of the host's hostgroup
+        """Get name of the first host's hostgroup (alphabetic sort)
 
         :return: host group name
         :rtype: str
-        TODO: Clean this. It returns the last hostgroup encountered
+        TODO: Clean this. It returns the first hostgroup (alphabetic sort)
         """
-        groupname = ''
-        for hostgroup_id in self.hostgroups:
-            hostgroup = hostgroups[hostgroup_id]
-            groupname = "%s" % (hostgroup.alias)
-        return groupname
+        group_names = self.get_groupnames(hostgroups).split(',')
+        return group_names[0]
+
+    def get_groupalias(self, hostgroups):
+        """Get alias of the first host's hostgroup (alphabetic sort on group alias)
+
+        :return: host group alias
+        :rtype: str
+        TODO: Clean this. It returns the first hostgroup alias (alphabetic sort)
+        """
+        group_aliases = self.get_groupaliases(hostgroups).split(',')
+        return group_aliases[0]
 
     def get_groupnames(self, hostgroups):
-        """Get aliases of the host's hostgroups
+        """Get names of the host's hostgroups
 
-        :return: comma separated aliases of hostgroups
+        :return: comma separated names of hostgroups alphabetically sorted
         :rtype: str
         """
-        groupnames = ''
+        group_names = []
         for hostgroup_id in self.hostgroups:
             hostgroup = hostgroups[hostgroup_id]
-            if groupnames == '':
-                groupnames = hostgroup.get_name()
-            else:
-                groupnames = "%s, %s" % (groupnames, hostgroup.get_name())
-        return groupnames
+            group_names.append(hostgroup.get_name())
+        return ','.join(sorted(group_names))
+
+    def get_groupaliases(self, hostgroups):
+        """Get aliases of the host's hostgroups
+
+        :return: comma separated aliases of hostgroups alphabetically sorted
+        :rtype: str
+        """
+        group_aliases = []
+        for hostgroup_id in self.hostgroups:
+            hostgroup = hostgroups[hostgroup_id]
+            group_aliases.append(hostgroup.alias)
+        return ','.join(sorted(group_aliases))
 
     def get_full_name(self):
         """Accessor to host_name attribute

--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -238,8 +238,9 @@ class Host(SchedulingItem):  # pylint: disable=R0904
         'TOTALHOSTSERVICES': 'get_total_services',
         'TOTALHOSTSERVICESOK': ('get_total_services_ok', ['services']),
         'TOTALHOSTSERVICESWARNING': ('get_total_services_warning', ['services']),
-        'TOTALHOSTSERVICESUNKNOWN': ('get_total_services_unknown', ['services']),
         'TOTALHOSTSERVICESCRITICAL': ('get_total_services_critical', ['services']),
+        'TOTALHOSTSERVICESUNKNOWN': ('get_total_services_unknown', ['services']),
+        'TOTALHOSTSERVICESUNREACHABLE': ('get_total_services_unreachable', ['services']),
         'HOSTBUSINESSIMPACT':  'business_impact',
     })
     # Todo: really unuseful ... should be removed, but let's discuss!
@@ -1108,8 +1109,7 @@ class Host(SchedulingItem):  # pylint: disable=R0904
                        if services[s].state_id == state))
 
     def get_total_services_ok(self, services):
-        """
-        Get number of services ok
+        """Get number of services ok
 
         :param services:
         :type services:
@@ -1119,8 +1119,7 @@ class Host(SchedulingItem):  # pylint: disable=R0904
         return self._tot_services_by_state(services, 0)
 
     def get_total_services_warning(self, services):
-        """
-        Get number of services warning
+        """Get number of services warning
 
         :param services:
         :type services:
@@ -1130,8 +1129,7 @@ class Host(SchedulingItem):  # pylint: disable=R0904
         return self._tot_services_by_state(services, 1)
 
     def get_total_services_critical(self, services):
-        """
-        Get number of services critical
+        """Get number of services critical
 
         :param services:
         :type services:
@@ -1141,8 +1139,7 @@ class Host(SchedulingItem):  # pylint: disable=R0904
         return self._tot_services_by_state(services, 2)
 
     def get_total_services_unknown(self, services):
-        """
-        Get number of services unknown
+        """Get number of services unknown
 
         :param services:
         :type services:
@@ -1150,6 +1147,16 @@ class Host(SchedulingItem):  # pylint: disable=R0904
         :rtype: int
         """
         return self._tot_services_by_state(services, 3)
+
+    def get_total_services_unreachable(self, services):
+        """Get number of services unreachable
+
+        :param services:
+        :type services:
+        :return: Number of services
+        :rtype: int
+        """
+        return self._tot_services_by_state(services, 4)
 
     def get_ack_author_name(self):
         """Get the author of the acknowledgement

--- a/test/cfg/cfg_macroresolver_environment.cfg
+++ b/test/cfg/cfg_macroresolver_environment.cfg
@@ -2,7 +2,7 @@ cfg_dir=default
 
 ; Configure specific Alignak parameters
 illegal_macro_output_chars=`~\$&|'"<>
-enable_environment_macros=0
+enable_environment_macros=1
 
 $USER1$=plugins
 $PLUGINSDIR$=$USER1$

--- a/test/test_macroresolver.py
+++ b/test/test_macroresolver.py
@@ -549,6 +549,39 @@ class MacroResolverTester(object):
         com = mr.resolve_command(cc, data, self._sched.macromodulations, self._sched.timeperiods)
         assert 'plugins/nothing you should not pass' == com
 
+    def test_host_macros(self):
+        """Test host macros
+        :return:
+        """
+        self.print_header()
+        mr = self.get_mr()
+        (svc, hst) = self.get_hst_svc()
+        data = [hst, svc]
+
+        # First group name
+        dummy_call = "special_macro!$HOSTGROUPNAME$"
+        cc = CommandCall({"commands": self.arbiter.conf.commands, "call": dummy_call})
+        com = mr.resolve_command(cc, data, self._sched.macromodulations, self._sched.timeperiods)
+        assert com == 'plugins/nothing allhosts'
+
+        # All group names
+        dummy_call = "special_macro!$HOSTGROUPNAMES$"
+        cc = CommandCall({"commands": self.arbiter.conf.commands, "call": dummy_call})
+        com = mr.resolve_command(cc, data, self._sched.macromodulations, self._sched.timeperiods)
+        assert com == 'plugins/nothing allhosts,hostgroup_01,up'
+
+        # First group alias
+        dummy_call = "special_macro!$HOSTGROUPALIAS$"
+        cc = CommandCall({"commands": self.arbiter.conf.commands, "call": dummy_call})
+        com = mr.resolve_command(cc, data, self._sched.macromodulations, self._sched.timeperiods)
+        assert com == 'plugins/nothing All Hosts'
+
+        # All group aliases
+        dummy_call = "special_macro!$HOSTGROUPALIASES$"
+        cc = CommandCall({"commands": self.arbiter.conf.commands, "call": dummy_call})
+        com = mr.resolve_command(cc, data, self._sched.macromodulations, self._sched.timeperiods)
+        assert com == 'plugins/nothing All Hosts,All Up Hosts,hostgroup_alias_01'
+
     def test_host_count_services_macros(self):
         """Test services count for an hostmacros
         :return:
@@ -664,7 +697,6 @@ class MacroResolverTester(object):
         cc = CommandCall({"commands": self.arbiter.conf.commands, "call": dummy_call})
         com = mr.resolve_command(cc, data, self._sched.macromodulations, self._sched.timeperiods)
         assert 'plugins/nothing 0' == com
-
 
     def test_contact_custom_macros(self):
         """

--- a/test/test_properties_default.py
+++ b/test/test_properties_default.py
@@ -53,6 +53,7 @@ import alignak.daemon
 from alignak_test import *
 from alignak.property import *
 
+
 class PropertiesTester(object):
 
     def test_unused_properties(self):
@@ -98,6 +99,7 @@ class PropertiesTester(object):
             if name.startswith('$') and name.endswith('$'):
                 continue
             assert name in prop_names, 'unknown property %r found' % name
+
 
 class TestConfig(PropertiesTester, AlignakTest):
 


### PR DESCRIPTION
This adds some tests for: 
- macros when `enable_environment_macros` is true/false
- host macros used to get the services count

--- 
Note that currently those supplementary tests do not raise the problem that @spea1 has on his configuration with the `enable_environment_macros` set to True 😯 