### PR TITLE
Use the freezgun module to manage time in some specific tests

### DIFF
--- a/test/test_external_commands.py
+++ b/test/test_external_commands.py
@@ -1020,11 +1020,12 @@ class TestExternalCommands(AlignakTest):
         self.external_command_loop()
         self.show_checks()
         self.assert_checks_count(2)
-        self.assert_checks_match(0, 'test_hostcheck.pl', 'command')
-        self.assert_checks_match(0, 'hostname test_host_0', 'command')
-        self.assert_checks_match(1, 'test_servicecheck.pl', 'command')
-        self.assert_checks_match(1, 'hostname test_host_0', 'command')
-        self.assert_checks_match(1, 'servicedesc test_ok_0', 'command')
+        # Host check and service may happen in any order... because launched almost simultaneously!
+        self.assert_any_check_match('test_hostcheck.pl', 'command')
+        self.assert_any_check_match('hostname test_host_0', 'command')
+        self.assert_any_check_match('test_servicecheck.pl', 'command')
+        self.assert_any_check_match('hostname test_host_0', 'command')
+        self.assert_any_check_match('servicedesc test_ok_0', 'command')
         assert 'DOWN' == router.state
         assert u'Host is DOWN' == router.output
         assert False == router.problem_has_been_acknowledged

--- a/test/test_retention.py
+++ b/test/test_retention.py
@@ -175,7 +175,8 @@ class Testretention(AlignakTest):
         commentshn = []
         for comm_uuid, comment in hostn.comments.iteritems():
             commentshn.append(comment.comment)
-        assert commentsh == commentshn
+        # Compare sorted comments because dictionairies are not ordered
+        assert sorted(commentsh) == sorted(commentshn)
 
         # check comments for service
         assert len(svc.comments) == len(svcn.comments)


### PR DESCRIPTION
Some tests often fail during the Travis build because of existing timestapms checked during some assertions, or in string messages ... using the freezegun module allow to mock the time.time() or most of the datetime module functions this to allow controlling the system time during the tests