### PR TITLE
Fix #909 - old Nagios unmanaged parameters only raise a warning

### DIFF
--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2163,38 +2163,38 @@ class Config(Item):  # pylint: disable=R0904,R0902
         valid = True
         if self.use_regexp_matching:
             msg = "use_regexp_matching parameter is not managed."
-            logger.error(msg)
-            self.configuration_errors.append(msg)
+            logger.warning(msg)
+            self.add_warning(msg)
             valid &= False
         if getattr(self, 'obsess_over_hosts', None):
             msg = "obsess_over_hosts parameter is not managed."
-            logger.error(msg)
-            self.configuration_errors.append(msg)
+            logger.warning(msg)
+            self.add_warning(msg)
             valid &= False
         if getattr(self, 'ochp_command', None):
             msg = "ochp_command parameter is not managed."
-            logger.error(msg)
-            self.configuration_errors.append(msg)
+            logger.warning(msg)
+            self.add_warning(msg)
             valid &= False
         if getattr(self, 'ochp_timeout', None):
             msg = "ochp_timeout parameter is not managed."
-            logger.error(msg)
-            self.configuration_errors.append(msg)
+            logger.warning(msg)
+            self.add_warning(msg)
             valid &= False
         if getattr(self, 'obsess_over_services', None):
             msg = "obsess_over_services parameter is not managed."
-            logger.error(msg)
-            self.configuration_errors.append(msg)
+            logger.warning(msg)
+            self.add_warning(msg)
             valid &= False
         if getattr(self, 'ocsp_command', None):
             msg = "ocsp_command parameter is not managed."
-            logger.error(msg)
-            self.configuration_errors.append(msg)
+            logger.warning(msg)
+            self.add_warning(msg)
             valid &= False
         if getattr(self, 'ocsp_timeout', None):
             msg = "ocsp_timeout parameter is not managed."
-            logger.error(msg)
-            self.configuration_errors.append(msg)
+            logger.warning(msg)
+            self.configuration_warnings.append(msg)
             valid &= False
         return valid
 
@@ -2220,9 +2220,9 @@ class Config(Item):  # pylint: disable=R0904,R0902
         # Globally unmanaged parameters
         if not self.read_config_silent:
             logger.info('Checking global parameters...')
-        if not self.check_error_on_hard_unmanaged_parameters():
-            valid = False
-            self.add_error("Check global parameters failed")
+
+        # Old Nagios legacy unmanaged parameters
+        self.check_error_on_hard_unmanaged_parameters()
 
         # If we got global event handlers, they should be valid
         if self.global_host_event_handler and not self.global_host_event_handler.is_valid():

--- a/test/cfg/config/deprecated_configuration_warning.cfg
+++ b/test/cfg/config/deprecated_configuration_warning.cfg
@@ -1,0 +1,275 @@
+# --------------------------------------------------------------------
+# Alignak main configuration file
+# --------------------------------------------------------------------
+# This file is the main file that will be loaded by Alignak on boot.
+# It is the entry point for the framework configuration.
+# --------------------------------------------------------------------
+# Please see the official project documentation for documentation about
+# the configuration:
+# http://alignak-doc.readthedocs.io/en/latest/04_configuration/index.html
+# --------------------------------------------------------------------
+
+
+# Here we define deprecated parameters for the test:
+disable_old_nagios_parameters_whining=1
+
+# Unmanaged parameters
+use_regexp_matching=1
+obsess_over_hosts=1
+obsess_over_services=1
+ochp_command=not_implemented
+ocsp_command=not_implemented
+
+# -------------------------------------------------------------------------
+# Monitored objects configuration part
+# -------------------------------------------------------------------------
+# Configuration files with common objects like commands, timeperiods,
+# or templates that are used by the host/service/contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+;cfg_dir=arbiter/objects/realms
+;cfg_dir=arbiter/objects/commands
+;cfg_dir=arbiter/objects/timeperiods
+;cfg_dir=arbiter/objects/escalations
+;cfg_dir=arbiter/objects/dependencies
+
+# Templates and packs for hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+;cfg_dir=arbiter/templates
+;cfg_dir=arbiter/packs
+
+# Notification ways
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+;cfg_dir=arbiter/objects/notificationways
+
+# Groups
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+;cfg_dir=arbiter/objects/servicegroups
+;cfg_dir=arbiter/objects/hostgroups
+;cfg_dir=arbiter/objects/contactgroups
+
+# Real hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+;cfg_dir=arbiter/objects/hosts
+;cfg_dir=arbiter/objects/services
+;cfg_dir=arbiter/objects/contacts
+
+# Alignak daemons and modules are loaded
+;cfg_dir=arbiter/daemons
+;cfg_dir=arbiter/modules
+
+# You will find global MACROS into the files in those directories
+;cfg_dir=arbiter/resource.d
+;cfg_dir=arbiter/packs/resource.d
+
+# -------------------------------------------------------------------------
+# Alignak framework configuration part
+# -------------------------------------------------------------------------
+
+# Alignak instance name
+# This information is useful to get/store alignak global configuration in the Alignak backend
+# If you share the same backend between several Alignak instances, each instance must have its own
+# name. The default is to use the arbiter name as Alignak instance name. Else, you can can define
+# your own Alignak instance name in this property
+# alignak_name=my_alignak
+
+# Notifications configuration
+# ---
+# Notifications are enabled/disabled
+# enable_notifications=1
+
+# After a timeout, launched plugins are killed
+#notification_timeout=30
+
+
+# Retention configuration
+# ---
+# Number of minutes between 2 retention save, default is 60 minutes
+#retention_update_interval=60
+
+# Checks configuration
+# ---
+# Active host/service checks are enabled/disabled
+#execute_host_checks=1
+#execute_service_checks=1
+
+# Passive host/service checks are enabled/disabled
+#accept_passive_host_checks=1
+#accept_passive_service_checks=1
+
+# As default, passive host checks are HARD states
+#passive_host_checks_are_soft=0
+
+
+# Interval length and re-scheduling configuration
+# Do not change those values unless you are reaaly sure to master what you are doing ...
+#interval_length=60
+#auto_reschedule_checks=1
+auto_rescheduling_interval=1
+auto_rescheduling_window=180
+
+
+# Number of interval to spread the first checks for hosts and services
+# Default is 30
+#max_service_check_spread=30
+max_service_check_spread=5
+# Default is 30
+#max_host_check_spread=30
+max_host_check_spread=5
+
+
+# Max plugin output for the plugins launched by the pollers, in bytes
+#max_plugins_output_length=8192
+max_plugins_output_length=65536
+
+
+# After a timeout, launched plugins are killed
+# and the host state is set to a default value (2 for DOWN)
+# and the service state is set to a default value (2 for CRITICAL)
+#host_check_timeout=30
+#service_check_timeout=60
+#timeout_exit_status=2
+
+
+# Freshness check
+# Default is enabled for hosts and services
+#check_host_freshness=1
+#check_service_freshness=1
+# Default is 60 for hosts and services
+#host_freshness_check_interval=60
+#service_freshness_check_interval=60
+# Extra time for freshness check ...
+#additional_freshness_latency=15
+
+
+# Flapping detection configuration
+# ---
+# Default is enabled
+#enable_flap_detection=1
+
+# Flapping threshold for hosts and services
+#low_service_flap_threshold=20
+#high_service_flap_threshold=30
+#low_host_flap_threshold=20
+#high_host_flap_threshold=30
+
+# flap_history is the lengh of history states we keep to look for flapping.
+# 20 by default, can be useful to increase it. Each flap_history increases cost:
+#    flap_history cost = 4Bytes * flap_history * (nb hosts + nb services)
+# Example: 4 * 20 * (1000+10000) ~ 900Ko for a quite big conf. So, go for it!
+#flap_history=20
+
+
+# Performance data configuration
+# ---
+# Performance data management is enabled/disabled
+#process_performance_data=1
+
+
+# Event handlers configuration
+# ---
+# Event handlers are enabled/disabled
+#enable_event_handlers=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+# Global host/service event handlers
+#global_host_event_handler=
+#global_service_event_handler=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# External commands configuration
+# ---
+# External commands are enabled/disabled
+# check_external_commands=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+
+# Impacts configuration
+# ---
+# Enable or not the state change on impact detection (like a host going unreachable
+# if a parent is DOWN for example). It's for services and hosts.
+# Note: defaults to 0 for Nagios old behavior compatibility
+#enable_problem_impacts_states_change=0
+enable_problem_impacts_states_change=1
+
+
+# if 1, disable all notice and warning messages at
+# configuration checking when arbiter checks the configuration.
+# Default is to log the notices and warnings
+#disable_old_nagios_parameters_whining=0
+disable_old_nagios_parameters_whining=1
+
+
+# Environment macros configuration
+# ---
+# Disabling environment macros is good for performance. If you really need it, enable it.
+#enable_environment_macros=1
+enable_environment_macros=0
+
+
+# Monitoring log configuration
+# ---
+# Note that alerts and downtimes are always logged
+# ---
+# Notifications
+# log_notifications=1
+
+# Services retries
+# log_service_retries=1
+
+# Hosts retries
+# log_host_retries=1
+
+# Event handlers
+# log_event_handlers=1
+
+# Flappings
+# log_flappings=1
+
+# Snapshots
+# log_snapshots=1
+
+# External commands
+# log_external_commands=1
+
+# Active checks
+# log_active_checks=0
+
+# Passive checks
+# log_passive_checks=0
+
+# Initial states
+# log_initial_states=1
+
+
+# [Optional], a pack distribution file is a local file near the arbiter
+# that will keep host pack id association, and so push same host on the same
+# scheduler if possible between restarts.
+pack_distribution_file=/usr/local/var/lib/alignak/pack_distribution.dat
+
+
+# If you need to set a specific timezone to your deamons, uncomment it
+#use_timezone=Europe/Paris
+
+
+# Export all alignak inner performances into a statsd server.
+# By default at localhost:8125 (UDP) with the alignak prefix
+# Default is not enabled
+#statsd_host=localhost
+#statsd_port=8125
+#statsd_prefix=alignak
+#statsd_enabled=0
+

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -548,7 +548,7 @@ class TestConfig(AlignakTest):
         self.show_logs()
 
         # Error messages
-        assert len(self.configuration_errors) == 12
+        assert len(self.configuration_errors) == 6
         self.assert_any_cfg_log_match(re.escape(
             "Your configuration parameters 'status_file = /tmp/status' and "
             "'object_cache_file = /tmp/cache' need to use an external module such "
@@ -576,6 +576,25 @@ class TestConfig(AlignakTest):
             "Your configuration parameter 'command_file = /tmp/command' needs to use an "
             "external module such as 'logs' but I did not found one!"
         ))
+
+        # Warning messages
+        assert len(self.configuration_warnings) == 9
+        self.assert_any_cfg_log_match(re.escape(
+            "Guessing the property obsess_over_hosts type because "
+            "it is not in Config object properties"
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "Guessing the property ochp_command type because "
+            "it is not in Config object properties"
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "Guessing the property obsess_over_services type because "
+            "it is not in Config object properties"
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "Guessing the property ocsp_command type because "
+            "it is not in Config object properties"
+        ))
         self.assert_any_cfg_log_match(re.escape(
             "use_regexp_matching parameter is not managed."
         ))
@@ -591,8 +610,52 @@ class TestConfig(AlignakTest):
         self.assert_any_cfg_log_match(re.escape(
             "obsess_over_services parameter is not managed."
         ))
+
+    def test_nagios_parameters_2(self):
+        """Configuration has some old nagios parameters - some are not raising a configuration error
+
+        :return: None
+        """
+        self.print_header()
+        self.setup_with_file('cfg/config/deprecated_configuration_warning.cfg')
+        assert self.conf_is_correct
+        self.show_logs()
+
+        # Error messages
+        assert len(self.configuration_errors) == 0
+
+        # Warning messages
+        assert len(self.configuration_warnings) == 9
         self.assert_any_cfg_log_match(re.escape(
-            "Check global parameters failed"
+            "Guessing the property obsess_over_hosts type because "
+            "it is not in Config object properties"
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "Guessing the property ochp_command type because "
+            "it is not in Config object properties"
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "Guessing the property obsess_over_services type because "
+            "it is not in Config object properties"
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "Guessing the property ocsp_command type because "
+            "it is not in Config object properties"
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "use_regexp_matching parameter is not managed."
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "ochp_command parameter is not managed."
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "obsess_over_hosts parameter is not managed."
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "ocsp_command parameter is not managed."
+        ))
+        self.assert_any_cfg_log_match(re.escape(
+            "obsess_over_services parameter is not managed."
         ))
 
     def test_broken_configuration_2(self):


### PR DESCRIPTION
With recent modifications, some old Nagios parameters made the configuration being refused as invalid by the Arbiter configuration parser. a simple Warning log for each non-managed parameter is enough...