### PR TITLE
Scheduler system consumption information

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ numpy>=1.9.0,<1.12.0; python_version < '2.7'
 numpy>=1.9.0; python_version >= '2.7'
 pyopenssl>=0.15
 docopt
+
+# Use psutil for scheduler TEST_LOG_MONITORING
+psutil

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,8 +2,6 @@
 -r ../requirements.txt
 unittest2
 mock
-# Use psutil
-psutil
 # Use py.test as test-runner
 pytest
 pytest-cov
@@ -21,5 +19,3 @@ freezegun
 -e git+git://github.com/Alignak-monitoring/alignak-module-example.git@develop#egg=alignak-module-example
 ordereddict==1.1
 requests_mock
-
-#psutil

--- a/test_load/test_daemons_single_instance.py
+++ b/test_load/test_daemons_single_instance.py
@@ -57,8 +57,8 @@ class TestDaemonsSingleInstance(AlignakTest):
         # Alignak do not run plugins but only simulate
         # os.environ['TEST_FAKE_ACTION'] = 'Yes'
 
-        # Alignak system self-monitoring
-        # os.environ['TEST_LOG_MONITORING'] = 'Yes'
+        # Alignak scheduler self-monitoring - report statistics every 5 loop counts
+        os.environ['TEST_LOG_MONITORING'] = ''
 
         # Declare environment to send stats to a file
         # os.environ['ALIGNAK_STATS_FILE'] = '/tmp/alignak.stats'

--- a/test_run/requirements.txt
+++ b/test_run/requirements.txt
@@ -1,8 +1,5 @@
 # this is the requirements dedicated to tests for daemons run.
 
-# Use psutil
-psutil
-
 # Alignak backend module (develop branch)
 -e git+git://github.com/Alignak-monitoring-contrib/alignak-module-backend.git@develop#egg=alignak-module-backend
 

--- a/test_run/test_launch_daemons_passive.py
+++ b/test_run/test_launch_daemons_passive.py
@@ -34,6 +34,9 @@ class TestLaunchDaemonsPassive(AlignakTest):
     def setUp(self):
         self.procs = {}
 
+        # Alignak scheduler self-monitoring - report statistics every 5 loop counts
+        os.environ['TEST_LOG_MONITORING'] = ''
+
     def checkDaemonsLogsForErrors(self, daemons_list):
         """
         Check that the daemons all started correctly and that they got their configuration


### PR DESCRIPTION
Use TEST_LOG_MONITORING environment variable to activate scheduler log for system health

The TEST_LOG_MONITORING variable may contain an integer value that is the report period. Each report period loop count, the scheduler will dump as INFO log its cpu, memory and disk metrics.