### PR TITLE
Fix #932: correctly manage global external commands in the receiver

### DIFF
--- a/alignak/dispatcher.py
+++ b/alignak/dispatcher.py
@@ -497,7 +497,7 @@ class Dispatcher:
 
                     # Special case for receiver because need to send it the hosts list
                     hnames = [h.get_name() for h in conf.hosts]
-                    sat_cfg['hosts'] = hnames
+                    sat_cfg['hosts_names'] = hnames
                     realm.to_satellites['receiver'][cfg_id] = sat_cfg
 
                     # The config is prepared for a scheduler, no need check another scheduler

--- a/test/alignak_test.py
+++ b/test/alignak_test.py
@@ -265,6 +265,7 @@ class AlignakTest(unittest.TestCase):
 
         # Build receivers dictionary with the receivers involved in the configuration
         for receiver in self.arbiter.dispatcher.receivers:
+            print("Receiver: %s" % receiver)
             self.receivers[receiver.receiver_name] = receiver
 
         # Build reactionners dictionary with the reactionners involved in the configuration
@@ -277,6 +278,18 @@ class AlignakTest(unittest.TestCase):
 
         # Initialize the Receiver with no daemon configuration file
         self.receiver = Receiver(None, False, False, False, False)
+        # if self.arbiter.dispatcher.satellites:
+        #     some_receivers = False
+        #     for satellite in self.arbiter.dispatcher.satellites:
+        #         if satellite.get_my_type() == 'receiver':
+        #             # self.receiver.load_modules_manager(satellite.name)
+        #             self.receiver.modules_manager = \
+        #                 ModulesManager('receiver', self.receiver.sync_manager,
+        #                                max_queue_size=getattr(self, 'max_queue_size', 0))
+        #
+        #             self.receiver.new_conf = satellite.cfg
+        #             if self.receiver.new_conf:
+        #                 self.receiver.setup_new_conf()
 
         # Initialize the Receiver with no daemon configuration file
         self.broker = Broker(None, False, False, False, False)
@@ -297,8 +310,9 @@ class AlignakTest(unittest.TestCase):
             self.eca = self.schedulers['scheduler-master'].sched.external_commands_manager
 
         # Now we create an external commands manager in receiver mode
-        self.ecr = ExternalCommandManager(self.receiver.cur_conf, 'receiver', self.receiver,
+        self.ecr = ExternalCommandManager(None, 'receiver', self.receiver,
                                           accept_unknown=True)
+        self.receiver.external_commands_manager = self.ecr
 
         # and an external commands manager in dispatcher mode
         self.ecd = ExternalCommandManager(self.arbiter.conf, 'dispatcher', self.arbiter,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -137,7 +137,7 @@ class TestConfig(AlignakTest):
         # Default Alignak name is the arbiter name
         assert self.arbiter.conf.alignak_name == 'arbiter-master'
 
-    def test_config_conf_inner_properties(self):
+    def test_config_conf_inner_properties_named_alignak(self):
         """ Default configuration with an alignak_name property
 
         :return: None

--- a/test/test_dispatcher.py
+++ b/test/test_dispatcher.py
@@ -290,7 +290,7 @@ class TestDispatcher(AlignakTest):
         # test get all hosts
         hosts = []
         for sched in self.receivers['receiver-master'].cfg['schedulers'].values():
-            hosts.extend(sched['hosts'])
+            hosts.extend(sched['hosts_names'])
         assert set(hosts) == set(['srv_001', 'srv_002', 'srv_003', 'srv_004', 'srv_101', 'srv_102',
                                  'srv_103', 'srv_104', 'srv_105', 'srv_106', 'srv_201', 'srv_202',
                                  'srv_203', 'srv_204', 'test_router_0', 'test_host_0'])

--- a/test/test_external_commands_passive_checks.py
+++ b/test/test_external_commands_passive_checks.py
@@ -662,7 +662,10 @@ class TestExternalCommandsPassiveChecks(AlignakTest):
         # Our receiver External Commands Manager DOES ACCEPT unknown passive checks...
         # This is to replace the normal setup_new_conf ...
         self._receiver.accept_passive_unknown_check_results = True
-        self._receiver.external_commands_manager.accept_passive_unknown_check_results = True
+        # Now create the external commands manager
+        # We are a receiver: our role is to get and dispatch commands to the schedulers
+        self._receiver.external_commands_manager = \
+            ExternalCommandManager(None, 'receiver', self._receiver,True)
 
         # Clear logs and broks
         self.clear_logs()

--- a/test/test_realms.py
+++ b/test/test_realms.py
@@ -412,6 +412,7 @@ class TestRealms(AlignakTest):
         """
         self.print_header()
         self.setup_with_file('cfg/cfg_realms_sub.cfg')
+        self.show_logs()
         assert self.conf_is_correct
 
         world = self.arbiter.conf.realms.find_by_name('World')


### PR DESCRIPTION
The receiver is currently only able to manage the commands related to hosts and services. When it receives a command for an host/service, it sends the command to the appropriate scheduler. But when it receives a "global" command it will forward this command to all the schedulers that it knows ...