### PR TITLE
[WiP] Fixes #951 - freshness check

### DIFF
--- a/.travis/unit.sh
+++ b/.travis/unit.sh
@@ -9,7 +9,7 @@ coverage erase
 # Run test suite with py.test running its coverage plugin
 # Verbose mode to have the test list
 # Dump the 10 slowest tests
-pytest -v --durations=10 --cov=alignak --cov-report term-missing --cov-config .coveragerc test_*.py
+pytest --durations=10 --cov=alignak --cov-report term-missing --cov-config .coveragerc test_*.py
 
 # Report about coverage
 coverage report -m

--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -173,7 +173,7 @@ class Host(SchedulingItem):  # pylint: disable=R0904
             IntegerProp(default=0, fill_brok=['full_status', 'check_result'], retention=True),
         'last_time_unreachable':
             IntegerProp(default=0, fill_brok=['full_status', 'check_result'], retention=True),
-        # no brok ,to much links
+        # no brok, too much links...
         'services':
             StringProp(default=[]),
         'realm_name':
@@ -668,21 +668,23 @@ class Host(SchedulingItem):  # pylint: disable=R0904
 
     def raise_freshness_log_entry(self, t_stale_by):
         """Raise freshness alert entry (warning level)
-        Format is : "The results of host '*get_name()*' are stale by *t_stale_by*
-                     (threshold=*t_threshold*).  I'm forcing an immediate check of the host."
-        Example : "Warning: The results of host 'Server' are stale by 0d 0h 0m 58s
-                   (threshold=0d 1h 0m 0s). ..."
+
+        Example : "The freshness period of host 'host_name' is expired
+                   by 0d 0h 17m 6s (threshold=0d 1h 0m 0s).
+                   Attempt: 1 / 1.
+                   I'm forcing the state to freshness state (d / HARD)"
 
         :param t_stale_by: time in seconds the host has been in a stale state
         :type t_stale_by: int
         :return: None
         """
-        logger.warning("The freshness period of host '%s' is expired by %s (threshold=%s). "
-                       "Attempt: %s / %s. "
+        logger.warning("The freshness period of host '%s' is expired by %s "
+                       "(threshold=%s + %ss). Attempt: %s / %s. "
                        "I'm forcing the state to freshness state (%s / %s).",
                        self.get_name(),
                        format_t_into_dhms_format(t_stale_by),
                        format_t_into_dhms_format(self.freshness_threshold),
+                       self.additional_freshness_latency,
                        self.attempt, self.max_check_attempts,
                        self.freshness_state, self.state_type)
         if self.is_max_attempts():

--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -685,6 +685,8 @@ class Host(SchedulingItem):  # pylint: disable=R0904
                        format_t_into_dhms_format(self.freshness_threshold),
                        self.attempt, self.max_check_attempts,
                        self.freshness_state, self.state_type)
+        if self.is_max_attempts():
+            self.freshness_log_raised = True
 
     def raise_notification_log_entry(self, notif, contact, host_ref=None):
         """Raise HOST NOTIFICATION entry (critical level)

--- a/alignak/objects/schedulingitem.py
+++ b/alignak/objects/schedulingitem.py
@@ -312,7 +312,8 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         'checks_in_progress':
             ListProp(default=[]),
         # no broks because notifications are too linked
-        'notifications_in_progress': DictProp(default={}, retention=True),
+        'notifications_in_progress':
+            DictProp(default={}, retention=True),
         'comments':
             DictProp(default={}, fill_brok=['full_status'], retention=True),
         'flapping_changes':
@@ -373,60 +374,77 @@ class SchedulingItem(Item):  # pylint: disable=R0902
         # we save only the names of the contacts, and we should RELINK
         # them when we load it.
         # use for having all contacts we have notified
-        'notified_contacts':  SetProp(default=set(),
-                                      retention=True,
-                                      retention_preparation=from_set_to_list),
-        'in_scheduled_downtime': BoolProp(
-            default=False, fill_brok=['full_status', 'check_result'], retention=True),
-        'in_scheduled_downtime_during_last_check': BoolProp(default=False, retention=True),
-        'actions':            ListProp(default=[]),  # put here checks and notif raised
-        'broks':              ListProp(default=[]),  # and here broks raised
+        'notified_contacts':
+            SetProp(default=set(), retention=True, retention_preparation=from_set_to_list),
+        'in_scheduled_downtime':
+            BoolProp(default=False, fill_brok=['full_status', 'check_result'], retention=True),
+        'in_scheduled_downtime_during_last_check':
+            BoolProp(default=False, retention=True),
+        'actions':
+            ListProp(default=[]),  # put here checks and notif raised
+        'broks':
+            ListProp(default=[]),  # and here broks raised
 
         # Problem/impact part
-        'is_problem':         BoolProp(default=False, fill_brok=['full_status']),
-        'is_impact':          BoolProp(default=False, fill_brok=['full_status']),
+        'is_problem':
+            BoolProp(default=False, fill_brok=['full_status']),
+        'is_impact':
+            BoolProp(default=False, fill_brok=['full_status']),
         # the save value of our business_impact for "problems"
-        'my_own_business_impact':   IntegerProp(default=-1, fill_brok=['full_status']),
+        'my_own_business_impact':
+            IntegerProp(default=-1, fill_brok=['full_status']),
         # list of problems that make us an impact
-        'source_problems':    ListProp(default=[],
-                                       fill_brok=['full_status'],
-                                       ),
+        'source_problems':
+            ListProp(default=[], fill_brok=['full_status']),
         # list of the impact I'm the cause of
-        'impacts':            ListProp(default=[],
-                                       fill_brok=['full_status'],
-                                       ),
+        'impacts':
+            ListProp(default=[], fill_brok=['full_status']),
         # keep a trace of the old state before being an impact
-        'state_before_impact': StringProp(default='PENDING'),
+        'state_before_impact':
+            StringProp(default='PENDING'),
         # keep a trace of the old state id before being an impact
-        'state_id_before_impact': IntegerProp(default=0),
+        'state_id_before_impact':
+            IntegerProp(default=0),
         # if the state change, we know so we do not revert it
-        'state_changed_since_impact': BoolProp(default=False),
+        'state_changed_since_impact':
+            BoolProp(default=False),
         # BUSINESS CORRELATOR PART
         # Say if we are business based rule or not
-        'got_business_rule': BoolProp(default=False, fill_brok=['full_status']),
+        'got_business_rule':
+            BoolProp(default=False, fill_brok=['full_status']),
         # Previously processed business rule (with macro expanded)
-        'processed_business_rule': StringProp(default="", fill_brok=['full_status']),
+        'processed_business_rule':
+            StringProp(default="", fill_brok=['full_status']),
         # Our Dependency node for the business rule
-        'business_rule': StringProp(default=None),
+        'business_rule':
+            StringProp(default=None),
         # Here it's the elements we are depending on
         # so our parents as network relation, or a host
         # we are depending in a hostdependency
         # or even if we are business based.
-        'parent_dependencies': SetProp(default=set(), fill_brok=['full_status']),
+        'parent_dependencies':
+            SetProp(default=set(), fill_brok=['full_status']),
         # Here it's the guys that depend on us. So it's the total
         # opposite of the parent_dependencies
-        'child_dependencies': SetProp(default=set(), fill_brok=['full_status']),
+        'child_dependencies':
+            SetProp(default=set(), fill_brok=['full_status']),
         # Manage the unknown/unreachable during hard state
-        'in_hard_unknown_reach_phase': BoolProp(default=False, retention=True),
-        'was_in_hard_unknown_reach_phase': BoolProp(default=False, retention=True),
+        'in_hard_unknown_reach_phase':
+            BoolProp(default=False, retention=True),
+        'was_in_hard_unknown_reach_phase':
+            BoolProp(default=False, retention=True),
         # Set if the element just change its father/son topology
-        'topology_change': BoolProp(default=False, fill_brok=['full_status']),
+        'topology_change':
+            BoolProp(default=False, fill_brok=['full_status']),
         # Trigger list
-        'triggers': ListProp(default=[]),
+        'triggers':
+            ListProp(default=[]),
         # snapshots part
-        'last_snapshot':  IntegerProp(default=0, fill_brok=['full_status'], retention=True),
+        'last_snapshot':
+            IntegerProp(default=0, fill_brok=['full_status'], retention=True),
         # Keep the string of the last command launched for this element
-        'last_check_command': StringProp(default=''),
+        'last_check_command':
+            StringProp(default=''),
         # Define if we are in the freshness expiration period
         'freshness_expired':
             BoolProp(default=False, fill_brok=['full_status'], retention=True),
@@ -1525,9 +1543,10 @@ class SchedulingItem(Item):  # pylint: disable=R0902
             if self.state != self.state_before_hard_unknown_reach_phase:
                 self.was_in_hard_unknown_reach_phase = False
 
-    def consume_result(self, chk, notif_period, hosts,  # pylint: disable=R0915,R0912,R0913
+    def consume_result(self, chk, notif_period, hosts,
                        services, timeperiods, macromodulations, checkmodulations, bi_modulations,
                        res_modulations, triggers, checks):
+        # pylint: disable=R0915,R0912,R0913,E1101
         """Consume a check return and send action in return
         main function of reaction of checks like raise notifications
 
@@ -1862,7 +1881,8 @@ class SchedulingItem(Item):  # pylint: disable=R0902
 
         # Raise a log if freshness check expired
         if self.freshness_expired and not self.freshness_log_raised:
-            self.raise_freshness_log_entry(int(now - self.last_state_update))
+            self.raise_freshness_log_entry(int(now - self.last_state_update -
+                                               self.freshness_threshold))
 
         # Now launch trigger if need. If it's from a trigger raised check,
         # do not raise a new one

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -675,22 +675,23 @@ class Service(SchedulingItem):
 
     def raise_freshness_log_entry(self, t_stale_by):
         """Raise freshness alert entry (warning level)
-        Format is : "The results of service '*get_name()*' on host '*host.get_name()*'
-                    are stale by *t_stale_by* (threshold=*t_threshold*).
-                    I'm forcing an immediate check of the service."
-        Example : "Warning: The results of service 'Load' on host 'Server' are stale by 0d 0h 0m 58s
-                   (threshold=0d 1h 0m 0s). ..."
+
+        Example : "The freshness period of service 'host_name/service_description' is expired
+                   by 0d 0h 17m 6s (threshold=0d 1h 0m 0s).
+                   Attempt: 1 / 1.
+                   I'm forcing the state to freshness state (x / HARD)"
 
         :param t_stale_by: time in seconds the service has been in a stale state
         :type t_stale_by: int
         :return: None
         """
-        logger.warning("The freshness period of service '%s' is expired by %s (threshold=%s). "
-                       "Attempt: %s / %s. "
+        logger.warning("The freshness period of service '%s' is expired by %s "
+                       "(threshold=%s + %ss). Attempt: %s / %s. "
                        "I'm forcing the state to freshness state (%s / %s).",
                        self.get_full_name(),
                        format_t_into_dhms_format(t_stale_by),
                        format_t_into_dhms_format(self.freshness_threshold),
+                       self.additional_freshness_latency,
                        self.attempt, self.max_check_attempts,
                        self.freshness_state, self.state_type)
         if self.is_max_attempts():

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -498,14 +498,13 @@ class Service(SchedulingItem):
 
     def set_state_from_exit_status(self, status, notif_period, hosts, services):
         """Set the state in UP, WARNING, CRITICAL, UNKNOWN or UNREACHABLE
-        according to the status of a check. Also updates the last_state
+        according to the status of a check result.
 
         :param status: integer between 0 and 4
         :type status: int
         :return: None
         """
         now = time.time()
-        self.last_state_update = now
 
         # we should put in last_state the good last state:
         # if not just change the state by an problem/impact
@@ -674,7 +673,7 @@ class Service(SchedulingItem):
             )
             self.broks.append(brok)
 
-    def raise_freshness_log_entry(self, t_stale_by, t_threshold):
+    def raise_freshness_log_entry(self, t_stale_by):
         """Raise freshness alert entry (warning level)
         Format is : "The results of service '*get_name()*' on host '*host.get_name()*'
                     are stale by *t_stale_by* (threshold=*t_threshold*).
@@ -684,16 +683,16 @@ class Service(SchedulingItem):
 
         :param t_stale_by: time in seconds the service has been in a stale state
         :type t_stale_by: int
-        :param t_threshold: threshold (seconds) to trigger this log entry
-        :type t_threshold: int
         :return: None
         """
-        logger.warning("The freshness period of service '%s' on host '%s' is expired "
-                       "by %s (threshold=%s). I'm forcing the state to freshness state (%s).",
-                       self.get_name(), self.host_name,
+        logger.warning("The freshness period of service '%s' is expired by %s (threshold=%s). "
+                       "Attempt: %s / %s. "
+                       "I'm forcing the state to freshness state (%s / %s).",
+                       self.get_full_name(),
                        format_t_into_dhms_format(t_stale_by),
-                       format_t_into_dhms_format(t_threshold),
-                       self.freshness_state)
+                       format_t_into_dhms_format(self.freshness_threshold),
+                       self.attempt, self.max_check_attempts,
+                       self.freshness_state, self.state_type)
 
     def raise_notification_log_entry(self, notif, contact, host_ref):
         """Raise SERVICE NOTIFICATION entry (critical level)

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -693,6 +693,8 @@ class Service(SchedulingItem):
                        format_t_into_dhms_format(self.freshness_threshold),
                        self.attempt, self.max_check_attempts,
                        self.freshness_state, self.state_type)
+        if self.is_max_attempts():
+            self.freshness_log_raised = True
 
     def raise_notification_log_entry(self, notif, contact, host_ref):
         """Raise SERVICE NOTIFICATION entry (critical level)

--- a/test/test_passive_checks.py
+++ b/test/test_passive_checks.py
@@ -335,17 +335,21 @@ class TestPassiveChecks(AlignakTest):
         # Set the host UP - this will run the scheduler loop to check for freshness
         expiry_date = time.strftime("%Y-%m-%d %H:%M:%S %Z")
         self.scheduler_loop(1, [[host, 0, 'UP']])
-        time.sleep(3)
+        time.sleep(1)
         self.scheduler_loop(1, [[host, 0, 'UP']])
-        time.sleep(3)
+        time.sleep(1)
         self.scheduler_loop(1, [[host, 0, 'UP']])
-        time.sleep(3)
+        time.sleep(1)
+        self.scheduler_loop(1, [[host, 0, 'UP']])
+        time.sleep(1)
         self.scheduler_loop(1, [[host, 0, 'UP']])
         time.sleep(0.1)
 
         assert "UNREACHABLE" == host_b.state
         assert True == host_b.freshness_expired
-        assert len(self.get_log_match("alignak.objects.host] The freshness period of host 'test_host_B'")) == 1
+        self.show_logs()
+        print len(self.get_log_match("alignak.objects.host] The freshness period of host 'test_host_B'"))
+        assert len(self.get_log_match("alignak.objects.host] The freshness period of host 'test_host_B'")) == 6
 
         # Now receive check_result (passive), so we must be outside of freshness_expired
         excmd = '[%d] PROCESS_HOST_CHECK_RESULT;test_host_B;0;Host is UP' % time.time()
@@ -355,4 +359,3 @@ class TestPassiveChecks(AlignakTest):
 
         assert "UP" == host_b.state
         assert False == host_b.freshness_expired
-


### PR DESCRIPTION
Fixes #951 : when an host is still marked as *freshness expired* no more checks are raised and the current attempt / max check attempt logic is not run

Probably fixes #865 : freshness checks and retention