### PR TITLE
For #962 - allow to get metrics about CPU and memory of the Alignak d…

### DIFF
--- a/alignak/objects/config.py
+++ b/alignak/objects/config.py
@@ -2697,7 +2697,7 @@ class Config(Item):  # pylint: disable=R0904,R0902
             cur_conf.contacts = self.contacts
             cur_conf.triggers = self.triggers
             cur_conf.escalations = self.escalations
-            # Create hostgroups with just the name and same id, but no members
+            # Create servicegroups with just the name and same id, but no members
             new_servicegroups = []
             for servicegroup in self.servicegroups:
                 new_servicegroups.append(servicegroup.copy_shell())

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ numpy>=1.9.0; python_version >= '2.7'
 pyopenssl>=0.15
 docopt
 
+# Use psutil for daemons memory monitoring (env ALIGNAK_DAEMONS_MONITORING)
 # Use psutil for scheduler TEST_LOG_MONITORING
 psutil

--- a/test_run/test_launch_daemons.py
+++ b/test_run/test_launch_daemons.py
@@ -506,6 +506,9 @@ class DaemonsStartTest(AlignakTest):
         """
         req = requests.Session()
 
+        # Set an environment variable to activate the logging of system cpu, memory and disk
+        os.environ['ALIGNAK_DAEMONS_MONITORING'] = '2'
+
         cfg_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                   'run/test_launch_daemons')
 

--- a/test_run/test_launch_daemons_realms_and_checks.py
+++ b/test_run/test_launch_daemons_realms_and_checks.py
@@ -182,6 +182,7 @@ class TestLaunchDaemonsRealms(AlignakTest):
         # Set an environment variable to activate the logging of checks execution
         # With this the pollers/schedulers will raise WARNING logs about the checks execution
         os.environ['TEST_LOG_ACTIONS'] = 'INFO'
+        os.environ['ALIGNAK_DAEMONS_MONITORING'] = '2'
 
         # Run daemons for 2 minutes
         self.run_and_check_alignak_daemons(120)


### PR DESCRIPTION
…aemons:

- add an information log
- send metrics to the StatsD if Alignak is configured for

Define an environment variable ALIGNAK_DAEMONS_MONITORING with the number of daemon loop iteration where a log and statsd sending should take place.