### PR TITLE
Allow to disable the scheduler internal commands checks. 

### DIFF
--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -318,10 +318,8 @@ class Daemon(object):
         # Log loop turns if environment variable is set
         self.log_loop = 'TEST_LOG_LOOP' in os.environ
 
-        # Activity information log period (every activity_log_period loop, raise a lo)
-        self.activity_log_period = 600
-        if 'ALIGNAK_ACTIVITY_LOG' in os.environ and os.environ['ALIGNAK_ACTIVITY_LOG']:
-            self.activity_log_period = int(os.environ['ALIGNAK_ACTIVITY_LOG'])
+        # Activity information log period (every activity_log_period loop, raise a log)
+        self.activity_log_period = int(os.getenv('ALIGNAK_ACTIVITY_LOG', 600))
 
         # Put in queue some debug output we will raise
         # when we will be in daemon
@@ -472,6 +470,9 @@ class Daemon(object):
                     logger.debug("Daemon %s (%s), pid=%s, ppid=%s, status=%s, cpu/memory|%s",
                                  self.name, my_process.name(), my_process.pid, my_process.ppid(),
                                  my_process.status(), " ".join(perfdatas))
+
+            if self.activity_log_period and (self.loop_count % self.activity_log_period == 1):
+                logger.info("Daemon %s is alive", self.name)
 
             if self.log_loop:
                 logger.debug("[%s] +++ %d", self.name, self.loop_count)

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -1345,10 +1345,20 @@ class Scheduler(object):  # pylint: disable=R0902
 
         :return: None
         """
+        if os.getenv('ALIGNAK_MANAGE_INTERNAL', '1') != '1':
+            return
         now = time.time()
         for chk in self.checks.values():
             # must be ok to launch, and not an internal one (business rules based)
             if chk.internal and chk.status == 'scheduled' and chk.is_launchable(now):
+                item = self.find_item_by_id(chk.ref)
+                # Only if active checks are enabled
+                if not item.active_checks_enabled:
+                    # Ask to remove the check
+                    chk.status = 'zombie'
+                    continue
+
+                # Count and execute only if active checks is enabled
                 self.nb_internal_checks += 1
                 self.counters["check"]["total"]["results"]["total"] += 1
                 if "internal" not in self.counters["check"]["total"]["results"]:
@@ -1360,14 +1370,10 @@ class Scheduler(object):  # pylint: disable=R0902
                     self.counters["check"]["loop"]["results"]["internal"] = 0
                 self.counters["check"]["loop"]["results"]["internal"] += 1
 
-                item = self.find_item_by_id(chk.ref)
-                # Only if active checks are enabled
-                if item.active_checks_enabled:
-                    item.manage_internal_check(self.hosts, self.services, chk, self.hostgroups,
-                                               self.servicegroups, self.macromodulations,
-                                               self.timeperiods)
-                # it manage it, now just ask to consume it
-                # like for all checks
+                item.manage_internal_check(self.hosts, self.services, chk, self.hostgroups,
+                                           self.servicegroups, self.macromodulations,
+                                           self.timeperiods)
+                # Ask to consume the check result
                 chk.status = 'waitconsume'
 
     def get_broks(self, bname):


### PR DESCRIPTION
The envionment variable ALIGNAK_MANAGE_INTERNAL may be set to a value different of '1' to disable the Alignak internal checks logic...