### PR TITLE
Improve stats and freshness checks

### DIFF
--- a/alignak/daemons/brokerdaemon.py
+++ b/alignak/daemons/brokerdaemon.py
@@ -137,7 +137,7 @@ class Broker(BaseSatellite):
         self.http_interface = BrokerInterface(self)
 
     def add(self, elt):  # pragma: no cover, seems not to be used
-        """Add elt to this broker
+        """Add an element to the broker lists
 
         Original comment : Schedulers have some queues. We can simplify the call by adding
           elements into the proper queue just by looking at their type  Brok -> self.broks
@@ -183,7 +183,7 @@ class Broker(BaseSatellite):
                     except KeyError:  # maybe this instance was not known, forget it
                         logger.warning("the module %s ask me a full_instance_id "
                                        "for an unknown ID (%d)!", source, c_id)
-            # Maybe a module tells me that it's dead, I must log it's last words...
+            # Maybe a module tells me that it's dead, I must log its last words...
             if elt.get_type() == 'ICrash':
                 data = elt.get_data()
                 logger.error('the module %s just crash! Please look at the traceback:',
@@ -191,7 +191,7 @@ class Broker(BaseSatellite):
                 logger.error(data['trace'])
 
             statsmgr.counter('message.added', 1)
-                # The module death will be looked for elsewhere and restarted.
+            # The module death will be looked for elsewhere and restarted.
 
     def manage_brok(self, brok):
         """Get a brok.
@@ -701,6 +701,7 @@ class Broker(BaseSatellite):
         # Get the list of broks not yet sent to our external modules
         t0 = time.time()
         broks_to_send = [brok for brok in self.broks if getattr(brok, 'to_be_sent', True)]
+        statsmgr.gauge('get-new-broks-count.to_send', len(broks_to_send))
 
         # Send the broks to all external modules to_q queue so they can get the whole packet
         # beware, the sub-process/queue can be die/close, so we put to restart the whole module

--- a/alignak/daemons/brokerdaemon.py
+++ b/alignak/daemons/brokerdaemon.py
@@ -699,7 +699,7 @@ class Broker(BaseSatellite):
         self.broks.sort(sort_by_ids)
 
         # Get the list of broks not yet sent to our external modules
-        t0 = time.time()
+        _t0 = time.time()
         broks_to_send = [brok for brok in self.broks if getattr(brok, 'to_be_sent', True)]
         statsmgr.gauge('get-new-broks-count.to_send', len(broks_to_send))
 
@@ -708,11 +708,11 @@ class Broker(BaseSatellite):
         # instead of killing ourselves :)
         for module in self.modules_manager.get_external_instances():
             try:
-                t00 = time.time()
+                _t00 = time.time()
                 queue_size = module.to_q.qsize()
                 statsmgr.gauge('queues.external.%s.to.size' % module.get_name(), queue_size)
                 module.to_q.put(broks_to_send)
-                statsmgr.timer('queues.external.%s.to.put' % module.get_name(), time.time() - t00)
+                statsmgr.timer('queues.external.%s.to.put' % module.get_name(), time.time() - _t00)
             except Exception as exp:  # pylint: disable=broad-except
                 # first we must find the modules
                 logger.warning("Module %s queue exception: %s, I'm tagging it to restart later",
@@ -723,7 +723,7 @@ class Broker(BaseSatellite):
         # No more need to send them
         for brok in broks_to_send:
             brok.to_be_sent = False
-        logger.debug("Time to send %s broks (%d secs)", len(broks_to_send), time.time() - t0)
+        logger.debug("Time to send %s broks (%d secs)", len(broks_to_send), time.time() - _t0)
 
         # We must add new broks at the end of the list, so we reverse the list
         self.broks.reverse()

--- a/alignak/objects/host.py
+++ b/alignak/objects/host.py
@@ -73,7 +73,6 @@ import logging
 from alignak.objects.schedulingitem import SchedulingItem, SchedulingItems
 
 from alignak.autoslots import AutoSlots
-from alignak.util import format_t_into_dhms_format
 from alignak.property import BoolProp, IntegerProp, StringProp, ListProp, CharProp
 from alignak.log import make_monitoring_log
 
@@ -665,30 +664,6 @@ class Host(SchedulingItem):  # pylint: disable=R0904
                 )
             )
             self.broks.append(brok)
-
-    def raise_freshness_log_entry(self, t_stale_by):
-        """Raise freshness alert entry (warning level)
-
-        Example : "The freshness period of host 'host_name' is expired
-                   by 0d 0h 17m 6s (threshold=0d 1h 0m 0s).
-                   Attempt: 1 / 1.
-                   I'm forcing the state to freshness state (d / HARD)"
-
-        :param t_stale_by: time in seconds the host has been in a stale state
-        :type t_stale_by: int
-        :return: None
-        """
-        logger.warning("The freshness period of host '%s' is expired by %s "
-                       "(threshold=%s + %ss). Attempt: %s / %s. "
-                       "I'm forcing the state to freshness state (%s / %s).",
-                       self.get_name(),
-                       format_t_into_dhms_format(t_stale_by),
-                       format_t_into_dhms_format(self.freshness_threshold),
-                       self.additional_freshness_latency,
-                       self.attempt, self.max_check_attempts,
-                       self.freshness_state, self.state_type)
-        if self.is_max_attempts() or self.state_type == 'HARD':
-            self.freshness_log_raised = True
 
     def raise_notification_log_entry(self, notif, contact, host_ref=None):
         """Raise HOST NOTIFICATION entry (critical level)

--- a/alignak/objects/service.py
+++ b/alignak/objects/service.py
@@ -77,7 +77,6 @@ from alignak.objects.schedulingitem import SchedulingItem, SchedulingItems
 from alignak.autoslots import AutoSlots
 from alignak.util import (
     strip_and_uniq,
-    format_t_into_dhms_format,
     generate_key_value_sequences,
     is_complex_expr,
     KeyValueSyntaxError)
@@ -672,30 +671,6 @@ class Service(SchedulingItem):
                 )
             )
             self.broks.append(brok)
-
-    def raise_freshness_log_entry(self, t_stale_by):
-        """Raise freshness alert entry (warning level)
-
-        Example : "The freshness period of service 'host_name/service_description' is expired
-                   by 0d 0h 17m 6s (threshold=0d 1h 0m 0s).
-                   Attempt: 1 / 1.
-                   I'm forcing the state to freshness state (x / HARD)"
-
-        :param t_stale_by: time in seconds the service has been in a stale state
-        :type t_stale_by: int
-        :return: None
-        """
-        logger.warning("The freshness period of service '%s' is expired by %s "
-                       "(threshold=%s + %ss). Attempt: %s / %s. "
-                       "I'm forcing the state to freshness state (%s / %s).",
-                       self.get_full_name(),
-                       format_t_into_dhms_format(t_stale_by),
-                       format_t_into_dhms_format(self.freshness_threshold),
-                       self.additional_freshness_latency,
-                       self.attempt, self.max_check_attempts,
-                       self.freshness_state, self.state_type)
-        if self.is_max_attempts() or self.state_type == 'HARD':
-            self.freshness_log_raised = True
 
     def raise_notification_log_entry(self, notif, contact, host_ref):
         """Raise SERVICE NOTIFICATION entry (critical level)

--- a/alignak/satellite.py
+++ b/alignak/satellite.py
@@ -1008,14 +1008,15 @@ class Satellite(BaseSatellite):  # pylint: disable=R0902
                          self.name, self.returns_queue.qsize())
             while self.returns_queue.qsize():
                 msg = self.returns_queue.get_nowait()
-                if msg is not None:
-                    logger.debug("Got a message: %s", msg)
-                    if msg.get_type() == 'Done':
-                        logger.debug("Got an action result: %s", msg.get_data())
-                        self.manage_action_return(msg.get_data())
-                        logger.debug("Managed action result")
-                    else:
-                        logger.warning("Ignoring message of type: %s", msg.get_type())
+                if msg is None:
+                    continue
+                logger.debug("Got a message: %s", msg)
+                if msg.get_type() == 'Done':
+                    logger.debug("Got an action result: %s", msg.get_data())
+                    self.manage_action_return(msg.get_data())
+                    logger.debug("Managed action result")
+                else:
+                    logger.warning("Ignoring message of type: %s", msg.get_type())
         except Full:
             logger.warning("Returns queue is full")
         except Empty:

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -2003,6 +2003,7 @@ class Scheduler(object):  # pylint: disable=R0902
 
         :return: None
         """
+        _t0 = time.time()
         items = []
         if self.conf.check_host_freshness:
             # Freshness check configured for hosts
@@ -2010,15 +2011,20 @@ class Scheduler(object):  # pylint: disable=R0902
         if self.conf.check_service_freshness:
             # Freshness check configured for services
             items.extend(self.services)
+        statsmgr.timer('freshness.items-list', time.time() - _t0)
 
         for elt in items:
             if elt.check_freshness and elt.passive_checks_enabled:
+                _t0 = time.time()
                 chk = elt.do_check_freshness(self.hosts, self.services, self.timeperiods,
                                              self.macromodulations, self.checkmodulations,
                                              self.checks)
+                statsmgr.timer('freshness.do-check', time.time() - _t0)
                 if chk is not None:
+                    _t0 = time.time()
                     self.add(chk)
                     self.waiting_results.put(chk)
+                    statsmgr.timer('freshness.put-check', time.time() - _t0)
 
     def check_orphaned(self):
         """Check for orphaned checks/actions::

--- a/alignak/scheduler.py
+++ b/alignak/scheduler.py
@@ -2006,25 +2006,32 @@ class Scheduler(object):  # pylint: disable=R0902
         _t0 = time.time()
         items = []
         if self.conf.check_host_freshness:
-            # Freshness check configured for hosts
-            items.extend(self.hosts)
+            # Freshness check is configured for hosts - get the list of concerned hosts:
+            # host check freshness is enabled and the host is only passively checked
+            hosts = [h for h in self.hosts if h.check_freshness and
+                     h.passive_checks_enabled and not h.active_checks_enabled]
+            statsmgr.gauge('freshness.hosts-count', len(hosts))
+            items.extend(hosts)
         if self.conf.check_service_freshness:
-            # Freshness check configured for services
-            items.extend(self.services)
+            # Freshness check is configured for services - get the list of concerned services:
+            # service check freshness is enabled and the service is only passively checked and
+            # the depending host is not freshness expired
+            services = [s for s in self.services if not self.hosts[s.host].freshness_expired and
+                        s.check_freshness and
+                        s.passive_checks_enabled and not s.active_checks_enabled]
+            statsmgr.gauge('freshness.services-count', len(services))
+            items.extend(services)
         statsmgr.timer('freshness.items-list', time.time() - _t0)
 
+        _t0 = time.time()
         for elt in items:
-            if elt.check_freshness and elt.passive_checks_enabled:
-                _t0 = time.time()
-                chk = elt.do_check_freshness(self.hosts, self.services, self.timeperiods,
-                                             self.macromodulations, self.checkmodulations,
-                                             self.checks)
-                statsmgr.timer('freshness.do-check', time.time() - _t0)
-                if chk is not None:
-                    _t0 = time.time()
-                    self.add(chk)
-                    self.waiting_results.put(chk)
-                    statsmgr.timer('freshness.put-check', time.time() - _t0)
+            chk = elt.do_check_freshness(self.hosts, self.services, self.timeperiods,
+                                         self.macromodulations, self.checkmodulations,
+                                         self.checks)
+            if chk is not None:
+                self.add(chk)
+                self.waiting_results.put(chk)
+        statsmgr.timer('freshness.do-check', time.time() - _t0)
 
     def check_orphaned(self):
         """Check for orphaned checks/actions::

--- a/test/alignak_test.py
+++ b/test/alignak_test.py
@@ -403,7 +403,35 @@ class AlignakTest(unittest.TestCase):
             for i in mysched.sched.recurrent_works:
                 (name, fun, nb_ticks) = mysched.sched.recurrent_works[i]
                 if nb_ticks == 1:
+                    # print("Execute: %s" % fun)
                     fun()
+
+    def manage_freshness_check(self, count=1, mysched=None):
+        """Run the scheduler loop for freshness_check
+
+        :param count: number of scheduler loop turns
+        :type count: int
+        :param mysched: a specific scheduler to get used
+        :type mysched: None | object
+        :return: n/a
+        """
+        if mysched is None:
+            mysched = self.schedulers['scheduler-master']
+
+        # Check freshness on each scheduler tick
+        mysched.sched.update_recurrent_works_tick('check_freshness', 1)
+
+        checks = []
+        for num in range(count):
+            for i in mysched.sched.recurrent_works:
+                (name, fun, nb_ticks) = mysched.sched.recurrent_works[i]
+                if nb_ticks == 1:
+                    fun()
+                if name == 'check_freshness':
+                    checks = sorted(mysched.sched.checks.values(),
+                                    key=lambda x: x.creation_time)
+                    checks = [chk for chk in checks if chk.freshness_expired]
+        return len(checks)
 
     def manage_external_command(self, external_command, run=True):
         """Manage an external command.


### PR DESCRIPTION
Improve broker and scheduler statistics for the freshness check process
Fix #983 : clean the scheduler freshness check process
 - include hosts in the freshness check list only if host check freshness is enabled and the host is only passively checked
 - include services in the freshness check list only if service check freshness is enabled and the service is only passively checked and the depending host is not freshness expired
 - repeat freshness with attempt/max attempts and raise a log on each repetition
 - stop raising a log once max attempts is raised (HARD freshness state is reached)