### PR TITLE
Fix broken requirement: CherryPy must be <9.0 !

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,12 +3,15 @@
 set -ev
 
 cd test_run
-# Delete previously existing coverage results
-coverage erase
 
+if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
 # Run test suite with py.test running its coverage plugin
-pytest -v --cov=alignak --cov-config .coveragerc test_*.py
+    # Dump the 10 slowest tests
+    pytest --durations=10 --cov=alignak --cov-report term-missing --cov-config .coveragerc test_*.py
+    # Report about coverage
+    coverage report -m
+else
+    pytest --durations=10 test_*.py
+fi
 
-# Report about coverage
-coverage report -m
 cd ..

--- a/.travis/unit.sh
+++ b/.travis/unit.sh
@@ -3,15 +3,16 @@
 set -ev
 
 cd test
-# Delete previously existing coverage results
-coverage erase
 
-# Run test suite with py.test running its coverage plugin
-# Verbose mode to have the test list
-# Dump the 10 slowest tests
-pytest --durations=10 --cov=alignak --cov-report term-missing --cov-config .coveragerc test_*.py
+if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+    # Run test suite with py.test running its coverage plugin
+    # Dump the 10 slowest tests
+    pytest --durations=10 --cov=alignak --cov-report term-missing --cov-config .coveragerc test_*.py
+    # Report about coverage
+    coverage report -m
+else
+    pytest --durations=10 test_*.py
+fi
 
-# Report about coverage
-coverage report -m
 cd ..
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ CherryPy<9.0.0
 # Requests to communicate between the daemons
 # Version <=2.14.2 else some tests using requests-mock are broken with the 2.16.0 version
 requests>=2.7.0,<=2.14.2
-# requests
 
 # importlib is used to import modules used by the daemons
 importlib
@@ -22,8 +21,6 @@ setproctitle
 ujson
 
 # numpy for date and percentile computation
-# numpy>=1.9.0,<1.12.0; python_version < '2.7'
-# numpy>=1.9.0; python_version >= '2.7'
 numpy<1.12.0; python_version < '2.7'
 numpy; python_version >= '2.7'
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -20,7 +20,7 @@ coverage
 coveralls
 
 # Static code analysis libraries
-pylint<1.8.0; python_version < '2.7'
+pylint<1.5.0; python_version < '2.7'
 pylint; python_version >= '2.7'
 pycodestyle
 pep257

--- a/test_run/test_launch_daemons_modules.py
+++ b/test_run/test_launch_daemons_modules.py
@@ -172,7 +172,7 @@ class TestLaunchDaemonsModules(AlignakTest):
             sleep(0.1)
             print("- %s launched (pid=%d)" % (daemon, self.procs[daemon].pid))
 
-        sleep(1)
+        sleep(3)
 
         print("Testing daemons start")
         for name, proc in self.procs.items():
@@ -678,7 +678,7 @@ class TestLaunchDaemonsModules(AlignakTest):
             'broker': 'backend_broker',
             'poller': '', 'reactionner': '', 'receiver': ''
         }
-        nb_errors = self._run_daemons_modules(cfg_folder, tmp_folder, cfg_modules, 120)
+        nb_errors = self._run_daemons_modules(cfg_folder, tmp_folder, cfg_modules, 20)
 
         # Search the WS module
         # module_pid = None
@@ -725,10 +725,10 @@ class TestLaunchDaemonsModules(AlignakTest):
                 "[alignak.modulesmanager] Loaded Python module 'alignak_module_backend.broker' (backend_broker)",
                 # "[alignak.module] Give an instance of alignak_module_backend.broker for alias: backend_broker",
                 "[alignak.module.backend_broker] Number of processes used by backend client: 1",
-                "[alignak.module.backend_broker] Alignak backend is not available for login. No backend connection, attempt: 1",
-                "[alignak.module.backend_broker] Alignak backend connection is not available. Checking if livestate update is allowed is not possible.",
-                "[alignak.modulesmanager] Trying to initialize module: backend_broker",
+                # "[alignak.module.backend_broker] Error on backend login: ",
+                "[alignak.module.backend_broker] Configured user account is not allowed for this module",
                 "[alignak.daemon] I correctly loaded my modules: [backend_broker]",
+                "[alignak.modulesmanager] Trying to initialize module: backend_broker",
             ],
             'scheduler': [
                 "[alignak.modulesmanager] Importing Python module 'alignak_module_backend.scheduler' for backend_scheduler...",
@@ -759,7 +759,9 @@ class TestLaunchDaemonsModules(AlignakTest):
                         print("--- %s" % line[:-1])
                     if 'ERROR:' in line:
                         print("*** %s" % line[:-1])
-                        if "Alignak backend connection is not available. " not in line:
+                        if "Error on backend login:" not in line \
+                            and "Configured user account is not allowed for this module" not in line \
+                            and "Alignak backend connection is not available. " not in line:
                             errors_raised += 1
                         line = line.split('ERROR: ')
                         line = line[1]


### PR DESCRIPTION
Restore CherryPy version < 9.0 requirement. Still necessary for some of the daemons features