### PR TITLE
Fixed Sensitive Data Exposure: Reset `umask`

### DIFF
--- a/alignak/daemon.py
+++ b/alignak/daemon.py
@@ -1468,7 +1468,7 @@ class Daemon(object):  # pylint: disable=too-many-instance-attributes
         print("Daemonizing %s..." % self.name)
 
         # Set umask
-        os.umask(UMASK)
+        mask = os.umask(UMASK)
 
         # Close all file descriptors except the one we need
         self.pre_log.append(("DEBUG", "Closing file descriptors..."))
@@ -1505,6 +1505,8 @@ class Daemon(object):  # pylint: disable=too-many-instance-attributes
 
         self.pid = os.getpid()
         self.pre_log.append(("INFO", "We are now fully daemonized :) pid=%d" % self.pid))
+        # Reset umask
+        os.umask(mask)
 
         return True
 


### PR DESCRIPTION
## Description
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [daemon.py](https://github.com/Alignak-monitoring/alignak/tree/develop/alignak/daemon.py#L1471), there is a method daemonize that grants permission to the others class which refers to all users except the owner and member of the file's group class. This may lead to undesired access to a confidential file. iCR replaced the loose permission with a stricter permission.

Setting `umask` to 0 can lead to dangerous situation. For example, executing the program will result in creating two files such as-
```python
import os

print("Before using umask")
with open("before.txt.bad", "w") as f:
	f.write("Hello World")

os.umask(0)
# do things
print("After using umask")

with open("after.txt.bad", "w") as f:
	f.write("Hello World 2")
```
```
-rw-rw-rw-  1 ataf ataf   13 Dec 12 15:21 after.txt.bad
-rw-rw-r--  1 ataf ataf   11 Dec 12 15:21 before.txt.bad
```

Whereas, if we reset the umask to previous value and then execute the program, we get-
```python
import os

print("Before using umask")
with open("before.txt.good", "w") as f:
	f.write("Hello World")

mask = os.umask(0)
# do things with umask here
os.umask(mask)

print("After using umask")
with open("after.txt.good", "w") as f:
	f.write("Hello World 2")
```
```
-rw-rw-r--  1 ataf ataf  221 Dec 12 15:18 bad.py
-rw-rw-r--  1 ataf ataf  261 Dec 12 15:18 good.py
```

## Changes
Since the `umask` is set to `0` for daemonizing a process, after it's done, it can be set to the previous value. As a result, the value of `umask` won't affect any future execution and won't lead to any data exposure issues.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
